### PR TITLE
Create initial redaction CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ This project has been funded in whole or in part with Federal funds from the Nat
 
 `pip install -r requirements.txt`
 
-`python imagedephi.py <path/to/image>`
+`python imagedephi.py <directory of input images> <directory to store redacted images>`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # ImageDePHI
 
 This project has been funded in whole or in part with Federal funds from the National Cancer Institute, National Institutes of Health, Department of Health and Human Services, under Contract No. 75N91022C00033
+
+## To Run as a CLI
+
+`pip install -r requirements.txt`
+
+`python imagedephi.py <path/to/image>`

--- a/imagedephi.py
+++ b/imagedephi.py
@@ -1,0 +1,77 @@
+import argparse
+from enum import Enum
+from pathlib import Path
+
+import tifftools
+from tifftools import Datatype
+
+
+class RedactMethod(Enum):
+    REPLACE = 1
+    DELETE = 2
+
+
+def get_tags_to_redact():
+    return {
+        270: {
+            'id': 270,
+            'name': 'ImageDescription',
+            'method': RedactMethod.REPLACE,
+            'replace_value': 'Redacted by ImageDePHI'
+        }
+    }
+
+
+def redact_one_tag(ifd, tag, redact_instructions):
+    if redact_instructions['method'] == RedactMethod.REPLACE:
+        ifd['tags'][tag.value]['data'] = redact_instructions['replace_value']
+    elif redact_instructions['method'] == RedactMethod.DELETE:
+        del ifd['tags'][tag.value]
+
+
+def redact_tiff_tags(ifds, tags_to_redact):
+    for ifd in ifds:
+        sub_ifd_list = []
+        for tag, tag_info in sorted(ifd['tags'].items()):
+            tag = tifftools.commands.get_or_create_tag(
+                tag,
+                tifftools.Tag,
+                {'datatype': Datatype[tag_info['datatype']]},
+            )
+            if not tag.isIFD() and tag_info['datatype'] not in (
+                Datatype.IFD,
+                Datatype.IFD8,
+            ):
+                if tag.value in tags_to_redact.keys():
+                    redact_one_tag(ifd, tag, tags_to_redact[tag.value])
+            else:
+                sub_ifd_list.append((tag, tag_info))
+        for tag, tag_info in sub_ifd_list:
+            for sub_ifds in tag_info['ifds']:
+                redact_tiff_tags(sub_ifds, tags_to_redact)
+
+
+def redact_one_image(image_path):
+    tiff_info = tifftools.read_tiff(image_path)
+    ifds = tiff_info['ifds']
+    tags_to_redact = get_tags_to_redact()
+    redact_tiff_tags(ifds, tags_to_redact)
+    output_image_path = (
+        str(image_path.parent) + '/REDACTED_' + str(image_path.name)
+    )
+    tifftools.write_tiff(tiff_info, output_image_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="Image DePHI",
+        description="A CLI for redacting whole slide microscopy images",
+    )
+    parser.add_argument("image", help="Path to the image file to be redacted")
+    args = parser.parse_args()
+    image_path = Path(args.image).resolve()
+    redact_one_image(image_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/imagedephi.py
+++ b/imagedephi.py
@@ -67,8 +67,9 @@ def redact_images(image_dir, output_dir):
         try:
             tiff_info = tifftools.read_tiff(child)
         except tifftools.exceptions.TifftoolsError:
-            print(f'Could not open {child} as a tiff. Skipping...')
+            print(f'Could not open {child.name} as a tiff. Skipping...')
             continue
+        print(f'Redacting {child.name}...')
         redact_one_image(tiff_info, get_output_path(child, output_dir))
 
 
@@ -97,6 +98,7 @@ def main():
         print('Output directory must be a directory')
         return
     redact_images(input_dir, output_dir)
+    print('Done!')
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+black
+flake8
+tifftools


### PR DESCRIPTION
This PR creates an initial CLI tool to lay out some framework for Image DePHI. 

Given a directory of images and a directory to write output to, the tool uses `tifftools` to open each image, traverse the `ifds` and replace the value of the `ImageDescription` tag (270) with `"Redacted by Image DePHI"`. The modified `ifds` are written as a new tiff in the specified output directory with the filename `REDACTED_<original file name>`.