### PR TITLE
Add initial tox/black/mypy config

### DIFF
--- a/imagedephi.py
+++ b/imagedephi.py
@@ -2,7 +2,6 @@ import argparse
 from enum import Enum
 from pathlib import Path
 import sys
-from typing import Dict, List
 
 import tifftools
 from tifftools import Datatype, TiffTag
@@ -13,7 +12,7 @@ class RedactMethod(Enum):
     DELETE = 2
 
 
-def get_tags_to_redact() -> Dict[int, Dict]:
+def get_tags_to_redact() -> dict[int, dict]:
     return {
         270: {
             'id': 270,
@@ -24,14 +23,14 @@ def get_tags_to_redact() -> Dict[int, Dict]:
     }
 
 
-def redact_one_tag(ifd: Dict, tag: TiffTag, redact_instructions: Dict) -> None:
+def redact_one_tag(ifd: dict, tag: TiffTag, redact_instructions: dict) -> None:
     if redact_instructions['method'] == RedactMethod.REPLACE:
         ifd['tags'][tag.value]['data'] = redact_instructions['replace_value']
     elif redact_instructions['method'] == RedactMethod.DELETE:
         del ifd['tags'][tag.value]
 
 
-def redact_tiff_tags(ifds: List[Dict], tags_to_redact: Dict[int, Dict]) -> None:
+def redact_tiff_tags(ifds: list[dict], tags_to_redact: dict[int, dict]) -> None:
     for ifd in ifds:
         sub_ifd_list = []
         for tag, tag_info in sorted(ifd['tags'].items()):
@@ -51,7 +50,7 @@ def redact_tiff_tags(ifds: List[Dict], tags_to_redact: Dict[int, Dict]) -> None:
                     redact_tiff_tags(sub_ifds, tags_to_redact)
 
 
-def redact_one_image(tiff_info: Dict, output_path: Path) -> None:
+def redact_one_image(tiff_info: dict, output_path: Path) -> None:
     ifds = tiff_info['ifds']
     tags_to_redact = get_tags_to_redact()
     redact_tiff_tags(ifds, tags_to_redact)

--- a/imagedephi.py
+++ b/imagedephi.py
@@ -50,7 +50,7 @@ def redact_tiff_tags(ifds: list[dict], tags_to_redact: dict[int, dict]) -> None:
                     redact_tiff_tags(sub_ifds, tags_to_redact)
 
 
-def redact_one_image(tiff_info: dict, output_path: Path) -> None:
+def redact_one_image(tiff_info: dict[str, list], output_path: Path) -> None:
     ifds = tiff_info['ifds']
     tags_to_redact = get_tags_to_redact()
     redact_tiff_tags(ifds, tags_to_redact)

--- a/imagedephi.py
+++ b/imagedephi.py
@@ -1,10 +1,11 @@
 import argparse
-import sys
 from enum import Enum
 from pathlib import Path
+import sys
+from typing import Dict, List
 
 import tifftools
-from tifftools import Datatype
+from tifftools import Datatype, TiffTag
 
 
 class RedactMethod(Enum):
@@ -12,25 +13,25 @@ class RedactMethod(Enum):
     DELETE = 2
 
 
-def get_tags_to_redact():
+def get_tags_to_redact() -> Dict[int, Dict]:
     return {
         270: {
             'id': 270,
             'name': 'ImageDescription',
             'method': RedactMethod.REPLACE,
-            'replace_value': 'Redacted by ImageDePHI'
+            'replace_value': 'Redacted by ImageDePHI',
         }
     }
 
 
-def redact_one_tag(ifd, tag, redact_instructions):
+def redact_one_tag(ifd: Dict, tag: TiffTag, redact_instructions: Dict) -> None:
     if redact_instructions['method'] == RedactMethod.REPLACE:
         ifd['tags'][tag.value]['data'] = redact_instructions['replace_value']
     elif redact_instructions['method'] == RedactMethod.DELETE:
         del ifd['tags'][tag.value]
 
 
-def redact_tiff_tags(ifds, tags_to_redact):
+def redact_tiff_tags(ifds: List[Dict], tags_to_redact: Dict[int, Dict]) -> None:
     for ifd in ifds:
         sub_ifd_list = []
         for tag, tag_info in sorted(ifd['tags'].items()):
@@ -47,21 +48,21 @@ def redact_tiff_tags(ifds, tags_to_redact):
                 # tag_info['ifds'] contains a list of lists
                 # see tifftools.read_tiff
                 for sub_ifds in tag_info['ifds']:
-                    redact_tiff_tags(sub_ifds)
+                    redact_tiff_tags(sub_ifds, tags_to_redact)
 
 
-def redact_one_image(tiff_info, output_path):
+def redact_one_image(tiff_info: Dict, output_path: Path) -> None:
     ifds = tiff_info['ifds']
     tags_to_redact = get_tags_to_redact()
     redact_tiff_tags(ifds, tags_to_redact)
     tifftools.write_tiff(tiff_info, output_path)
 
 
-def get_output_path(file_path, output_dir):
-    return output_dir/f'REDACTED_{file_path.name}'
+def get_output_path(file_path: Path, output_dir: Path) -> Path:
+    return output_dir / f'REDACTED_{file_path.name}'
 
 
-def redact_images(image_dir, output_dir):
+def redact_images(image_dir: Path, output_dir: Path) -> None:
     for child in image_dir.iterdir():
         try:
             tiff_info = tifftools.read_tiff(child)
@@ -82,11 +83,7 @@ def main():
         help='Directory of images to redact',
         type=Path,
     )
-    parser.add_argument(
-        'output_dir',
-        help='Directory to store redacted images',
-        type=Path
-    )
+    parser.add_argument('output_dir', help='Directory to store redacted images', type=Path)
     args = parser.parse_args()
     input_dir = Path(args.input_dir).resolve()
     output_dir = Path(args.output_dir).resolve()
@@ -100,5 +97,5 @@ def main():
     print('Done!')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+ignore_missing_imports = True
+show_error_codes = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,0 @@
-[mypy]
-ignore_missing_imports = True
-show_error_codes = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,7 @@ profile = "black"
 line_length = 100
 force_sort_within_sections = true
 combine_as_imports = true
+
+[tool.mypy]
+ignore_missing_imports = true
+show_error_codes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.black]
+line-length = 100
+skip-string-normalization = true
+target-version = ["py310"]
+exclude='\.git|\.tox'
+
+[tool.isort]
+profile = "black"
+line_length = 100
+force_sort_within_sections = true
+combine_as_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 line-length = 100
 skip-string-normalization = true
 target-version = ["py310"]
-exclude='\.git|\.tox'
 
 [tool.isort]
 profile = "black"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
-black
-flake8
-isort
-mypy
 tifftools
 tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 black
 flake8
+isort
+mypy
 tifftools
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,49 @@
+[tox]
+envlist =
+    lint,
+    type
+
+[testenv:lint]
+skipsdist = true
+skip_install = true
+deps =
+    flake8<6
+    flake8-black
+    flake8-bugbear
+    flake8-docstrings
+    flake8-isort
+    flake8-quotes
+commands =
+    flake8 {posargs:.}
+
+[testenv:format]
+skipsdist = true
+skip_install = true
+deps =
+    black
+    isort
+commands =
+    isort {posargs:.}
+    black {posargs:.}
+
+[testenv:type]
+skipsdist = true
+skip_install = true
+deps =
+    mypy
+commands =
+    mypy {posargs:.}
+
+[flake8]
+max-line-length = 100
+show-source = true
+ignore =
+    # closing bracket does not match indentation of opening bracket’s line
+    E123,
+    # whitespace before ':'
+    E203,
+    # line break before binary operator
+    W503,
+    # Missing docstring in *
+    D10,
+black-config = pyproject.toml

--- a/tox.ini
+++ b/tox.ini
@@ -47,4 +47,3 @@ ignore =
     W503,
     # Missing docstring in *
     D10,
-black-config = pyproject.toml

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     flake8-docstrings
     flake8-isort
     flake8-quotes
+    pep8-naming
 commands =
     flake8 {posargs:.}
 


### PR DESCRIPTION
This PR adds some testing for Image DePHI, which can be built upon to accommodate more kinds of testing.

We are using `tox` to configure tests. For now, linting, import sorting, type checking, and formatting have been added.