### PR TITLE
Allow Black to handle string quote formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Reformat code to standardize double quoted strings
+bb0159f16a038c8689c242c575607c31a843aed7

--- a/imagedephi.py
+++ b/imagedephi.py
@@ -18,27 +18,27 @@ class RedactMethod(Enum):
 def get_tags_to_redact() -> dict[int, dict[str, Any]]:
     return {
         270: {
-            'id': 270,
-            'name': 'ImageDescription',
-            'method': RedactMethod.REPLACE,
-            'replace_value': 'Redacted by ImageDePHI',
+            "id": 270,
+            "name": "ImageDescription",
+            "method": RedactMethod.REPLACE,
+            "replace_value": "Redacted by ImageDePHI",
         }
     }
 
 
 def redact_one_tag(ifd: IFD, tag: tifftools.TiffTag, redact_instructions: dict[str, Any]) -> None:
-    if redact_instructions['method'] == RedactMethod.REPLACE:
-        ifd['tags'][tag.value]['data'] = redact_instructions['replace_value']
-    elif redact_instructions['method'] == RedactMethod.DELETE:
-        del ifd['tags'][tag.value]
+    if redact_instructions["method"] == RedactMethod.REPLACE:
+        ifd["tags"][tag.value]["data"] = redact_instructions["replace_value"]
+    elif redact_instructions["method"] == RedactMethod.DELETE:
+        del ifd["tags"][tag.value]
 
 
 def redact_tiff_tags(ifds: list[IFD], tags_to_redact: dict[int, dict[str, Any]]) -> None:
     for ifd in ifds:
-        for tag_id, tag_info in sorted(ifd['tags'].items()):
+        for tag_id, tag_info in sorted(ifd["tags"].items()):
             tag: tifftools.TiffTag = tifftools.constants.get_or_create_tag(
                 tag_id,
-                datatype=tifftools.Datatype[tag_info['datatype']],
+                datatype=tifftools.Datatype[tag_info["datatype"]],
             )
             if not tag.isIFD():
                 if tag.value in tags_to_redact:
@@ -46,19 +46,19 @@ def redact_tiff_tags(ifds: list[IFD], tags_to_redact: dict[int, dict[str, Any]])
             else:
                 # tag_info['ifds'] contains a list of lists
                 # see tifftools.read_tiff
-                for sub_ifds in tag_info['ifds']:
+                for sub_ifds in tag_info["ifds"]:
                     redact_tiff_tags(sub_ifds, tags_to_redact)
 
 
 def redact_one_image(tiff_info: TiffInfo, output_path: Path) -> None:
-    ifds = tiff_info['ifds']
+    ifds = tiff_info["ifds"]
     tags_to_redact = get_tags_to_redact()
     redact_tiff_tags(ifds, tags_to_redact)
     tifftools.write_tiff(tiff_info, output_path)
 
 
 def get_output_path(file_path: Path, output_dir: Path) -> Path:
-    return output_dir / f'REDACTED_{file_path.name}'
+    return output_dir / f"REDACTED_{file_path.name}"
 
 
 def redact_images(image_dir: Path, output_dir: Path) -> None:
@@ -66,30 +66,30 @@ def redact_images(image_dir: Path, output_dir: Path) -> None:
         try:
             tiff_info: TiffInfo = tifftools.read_tiff(child)
         except tifftools.TifftoolsError:
-            print(f'Could not open {child.name} as a tiff. Skipping...')
+            print(f"Could not open {child.name} as a tiff. Skipping...")
             continue
-        print(f'Redacting {child.name}...')
+        print(f"Redacting {child.name}...")
         redact_one_image(tiff_info, get_output_path(child, output_dir))
 
 
 def is_directory(cli_argument: str) -> Path:
     path = Path(cli_argument).resolve()
     if not path.is_dir():
-        raise argparse.ArgumentTypeError(f'{cli_argument} is not a directory')
+        raise argparse.ArgumentTypeError(f"{cli_argument} is not a directory")
     return path
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        prog='Image DePHI',
-        description='A CLI for redacting whole slide microscopy images',
+        prog="Image DePHI",
+        description="A CLI for redacting whole slide microscopy images",
     )
-    parser.add_argument('input_dir', help='Directory of images to redact', type=is_directory)
-    parser.add_argument('output_dir', help='Directory to store redacted images', type=is_directory)
+    parser.add_argument("input_dir", help="Directory of images to redact", type=is_directory)
+    parser.add_argument("output_dir", help="Directory to store redacted images", type=is_directory)
     args = parser.parse_args()
     redact_images(args.input_dir, args.output_dir)
-    print('Done!')
+    print("Done!")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.black]
 line-length = 100
-skip-string-normalization = true
 target-version = ["py310"]
 
 [tool.isort]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(
-    name='ImageDePHI',
-    install_requires=['tifftools'],
-    entry_points={'console_scripts': ['imagedephi=imagedephi:main']},
+    name="ImageDePHI",
+    install_requires=["tifftools"],
+    entry_points={"console_scripts": ["imagedephi=imagedephi:main"]},
 )

--- a/stubs/tifftools/__init__.pyi
+++ b/stubs/tifftools/__init__.pyi
@@ -5,14 +5,14 @@ from .tifftools import read_tiff, write_tiff
 __version__: str
 
 __all__ = [
-    'Datatype',
-    'TiffDatatype',
-    'Tag',
-    'TiffTag',
-    'TifftoolsError',
-    'UnknownTagError',
-    'MustBeBigTiffError',
-    'read_tiff',
-    'write_tiff',
-    '__version__',
+    "Datatype",
+    "TiffDatatype",
+    "Tag",
+    "TiffTag",
+    "TifftoolsError",
+    "UnknownTagError",
+    "MustBeBigTiffError",
+    "read_tiff",
+    "write_tiff",
+    "__version__",
 ]

--- a/stubs/tifftools/constants.pyi
+++ b/stubs/tifftools/constants.pyi
@@ -10,7 +10,7 @@ class TiffConstant(int):
     def __getitem__(self, key: str) -> _TiffConstantAttr: ...
     def get(self, key: str, default: _TiffConstantAttr = ...) -> _TiffConstantAttr: ...
 
-_TiffConstantT = TypeVar('_TiffConstantT', bound=TiffConstant)
+_TiffConstantT = TypeVar("_TiffConstantT", bound=TiffConstant)
 
 class TiffConstantSet(Generic[_TiffConstantT]):
     def __init__(

--- a/stubs/tifftools/tifftools.pyi
+++ b/stubs/tifftools/tifftools.pyi
@@ -10,7 +10,7 @@ class TiffInfo(TypedDict):
     header: bytes
     bigEndian: bool
     bigtiff: bool
-    endianPack: Literal['>', '<']
+    endianPack: Literal[">", "<"]
     firstifd: int
 
 class IFD(TypedDict):

--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,11 @@ envlist =
 skipsdist = true
 skip_install = true
 deps =
-    flake8<6
+    flake8
     flake8-black
     flake8-bugbear
     flake8-docstrings
     flake8-isort
-    flake8-quotes
     pep8-naming
 commands =
     flake8 {posargs:.}


### PR DESCRIPTION
This has several benefits:
* String quotes are now auto-formatted correctly; no need to fix quote-related Flake8 errors by hand.
  * Continue to type the quotes however you want. Black will just fix them afterwards.
* We can unpin Flake8.

Note the addition of `.git-blame-ignore-revs`, to avoid `git blame` attribution of these automated changes. See https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/ and [run `git config --global blame.ignoreRevsFile .git-blame-ignore-revs` locally if you want automatic support](https://michaelheap.com/git-ignore-rev/).