### PR TITLE
Create initial functional tests

### DIFF
--- a/tests/data/input/test_image.tif
+++ b/tests/data/input/test_image.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2adf13410f2bb93ad0bbe693c5e2288c590e6935f4be812c2234faf755780b44
+size 58788

--- a/tests/test_redact_images.py
+++ b/tests/test_redact_images.py
@@ -1,41 +1,28 @@
 from pathlib import Path
 
-import tifftools
+from click.testing import CliRunner
+import pytest
 
-import imagedephi
-
-
-def verify_redaction_one_tag(ifd, tag, rule):
-    if rule['method'] == imagedephi.RedactMethod.REPLACE:
-        assert ifd['tags'][tag.value]['data'] == rule['replace_value']
-    elif rule['method'] == imagedephi.RedactMethod.DELETE:
-        assert tag.value not in ifd['tags']
+from imagedephi.__main__ import main
 
 
-def verify_redaction(ifds, rules):
-    for ifd in ifds:
-        for tag, tag_info in ifd['tags'].items():
-            tiff_tag = tifftools.constants.get_or_create_tag(
-                tag, tifftools.Tag, datatype=tifftools.Datatype[tag_info['datatype']]
-            )
-            if not tiff_tag.isIFD():
-                if tiff_tag.value in rules:
-                    verify_redaction_one_tag(ifd, tiff_tag, rules[tiff_tag.value])
-            else:
-                for sub_ifds in tag_info['ifds']:
-                    verify_redaction(sub_ifds, rules)
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
 
 
-def test_redact_images(tmp_path, mocker):
-    redact_one_image_spy = mocker.spy(imagedephi, 'redact_one_image')
-    input_dir = Path(__file__).parent / 'data' / 'input'
-    output_dir = tmp_path / 'output'
-    output_dir.mkdir()
-    imagedephi.redact_images(input_dir, output_dir)
+@pytest.fixture
+def data_dir() -> Path:
+    return Path(__file__).parent / "data"
 
-    assert redact_one_image_spy.call_count == 1
 
-    # ensure that each output file is properly redacted
-    for output_file in output_dir.iterdir():
-        tiff_info = tifftools.read_tiff(output_file)
-        verify_redaction(tiff_info['ifds'], imagedephi.get_tags_to_redact())
+def test_e2e(data_dir: Path, tmp_path: Path, runner: CliRunner) -> None:
+    result = runner.invoke(main, [str(data_dir / "input"), str(tmp_path)])
+
+    assert result.exit_code == 0
+    output_file = tmp_path / "REDACTED_test_image.tif"
+    assert output_file.exists()
+    with output_file.open("rb") as output_file_stream:
+        output_file_bytes = output_file_stream.read()
+        assert b"large_image_converter" not in output_file_bytes
+        assert b"Redacted by ImageDePHI" in output_file_bytes

--- a/tests/test_redact_images.py
+++ b/tests/test_redact_images.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import tifftools
+
+import imagedephi
+
+
+def verify_redaction_one_tag(ifd, tag, rule):
+    if rule['method'] == imagedephi.RedactMethod.REPLACE:
+        assert ifd['tags'][tag.value]['data'] == rule['replace_value']
+    elif rule['method'] == imagedephi.RedactMethod.DELETE:
+        assert tag.value not in ifd['tags']
+
+
+def verify_redaction(ifds, rules):
+    for ifd in ifds:
+        for tag, tag_info in ifd['tags'].items():
+            tiff_tag = tifftools.constants.get_or_create_tag(
+                tag, tifftools.Tag, datatype=tifftools.Datatype[tag_info['datatype']]
+            )
+            if not tiff_tag.isIFD():
+                if tiff_tag.value in rules:
+                    verify_redaction_one_tag(ifd, tiff_tag, rules[tiff_tag.value])
+            else:
+                for sub_ifds in tag_info['ifds']:
+                    verify_redaction(sub_ifds, rules)
+
+
+def test_redact_images(tmp_path, mocker):
+    redact_one_image_spy = mocker.spy(imagedephi, 'redact_one_image')
+    input_dir = Path(__file__).parent / 'data' / 'input'
+    output_dir = tmp_path / 'output'
+    output_dir.mkdir()
+    imagedephi.redact_images(input_dir, output_dir)
+
+    assert redact_one_image_spy.call_count == 1
+
+    # ensure that each output file is properly redacted
+    for output_file in output_dir.iterdir():
+        tiff_info = tifftools.read_tiff(output_file)
+        verify_redaction(tiff_info['ifds'], imagedephi.get_tags_to_redact())

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@
 minversion = 4
 env_list =
     lint,
-    type
+    type,
+    test
 
 [testenv]
 base_python = python3.10
@@ -35,6 +36,13 @@ deps =
     mypy
 commands =
     mypy {posargs:.}
+
+[testenv:test]
+deps =
+    pytest
+    pytest-mock
+commands =
+    pytest tests {posargs}
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
Resolves #4 

Now our testing suite contains a new environment called `test`, which will run `pytest` tests for Image DePHI. There is now a single test that tests the `redact_images` method, as well as some test data (a blank tiff image created by `large_image_converter`).
