### PR TITLE
Add PEP 517 build information

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 100
 target-version = ["py310"]


### PR DESCRIPTION
This allows pip (and Tox via pip) to use modern build system hooks to communicate with setuptools, instead of the legacy pathway.