### PR TITLE
Use PEP 621 for setuptools metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,17 @@
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "ImageDePHI"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "tifftools",
+]
+
+[project.scripts]
+imagedephi = "imagedephi:main"
+
 [tool.black]
 line-length = 100
 target-version = ["py310"]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,0 @@
-from setuptools import setup
-
-setup(
-    name="ImageDePHI",
-    install_requires=["tifftools"],
-    entry_points={"console_scripts": ["imagedephi=imagedephi:main"]},
-)


### PR DESCRIPTION
This provides stronger validation (since the information is static, not dynamically computed by executing `setup.py`). It is also the preferred format for `setuptools-scm`, which will help with dynamic versioning in the future.

Fixes #21.