### PR TITLE
Enable postponed evaluation of annotations

### DIFF
--- a/imagedephi/__init__.py
+++ b/imagedephi/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 from enum import Enum
 from pathlib import Path


### PR DESCRIPTION
At runtime (when `TYPE_CHECKING` is False), some of the annotation symbols are not actually defined.