### PR TITLE
Add a "--version" option and internal support for git-based versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os:
-          # Use an older Linux: https://pyinstaller.org/en/stable/usage.html#making-gnu-linux-apps-forward-compatible 
+          # Use an older Linux: https://pyinstaller.org/en/stable/usage.html#making-gnu-linux-apps-forward-compatible
           - ubuntu-20.04
           - macos-latest
           - windows-latest
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: true
+          # Tags are needed to compute the current version number
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,12 @@
 recursive-include imagedephi *.yaml *.j2
 
+prune .github
+prune stubs
 prune tests
+
+exclude .editorconfig
+exclude .git-blame-ignore-revs
+exclude .gitattributes
+exclude .gitignore
+exclude requirements.txt
+exclude tox.ini

--- a/imagedephi/main.py
+++ b/imagedephi/main.py
@@ -29,6 +29,7 @@ class ImagedephiContext:
     subcommand_name="gui",
     should_fallthrough=launched_from_windows_explorer,
 )
+@click.version_option(prog_name="ImageDePHI")
 @click.option(
     "-r",
     "--override-rules",

--- a/imagedephi/main.py
+++ b/imagedephi/main.py
@@ -34,7 +34,7 @@ class ImagedephiContext:
     "-r",
     "--override-rules",
     type=click.File("r"),
-    help="User-defined rules to override defaults",
+    help="User-defined rules to override defaults.",
 )
 @click.pass_context
 def imagedephi(ctx: click.Context, override_rules: TextIO | None) -> None:
@@ -58,7 +58,7 @@ def imagedephi(ctx: click.Context, override_rules: TextIO | None) -> None:
     "--overwrite-existing-output",
     is_flag=True,
     default=False,
-    help="Overwrite previous output for input images",
+    help="Overwrite previous output for input images.",
 )
 @click.pass_obj
 def run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "ImageDePHI"
-version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
     "click",
@@ -15,12 +14,15 @@ dependencies = [
     "hypercorn",
     "pyyaml",
 ]
+dynamic = ["version"]
 
 [project.scripts]
 imagedephi = "imagedephi.main:imagedephi"
 
 [tool.setuptools.packages.find]
 include = ["imagedephi*"]
+
+[tool.setuptools_scm]
 
 [tool.djlint]
 extension = "html.j2"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -31,6 +31,7 @@ def test_e2e_run(cli_runner: CliRunner, data_dir: Path, tmp_path: Path) -> None:
             str(tmp_path),
         ],
     )
+
     assert result.exit_code == 0
     output_file = tmp_path / "REDACTED_test_image.tif"
     assert output_file.exists()
@@ -50,6 +51,7 @@ def test_e2e_plan(cli_runner: CliRunner, data_dir: Path) -> None:
             str(data_dir / "input" / "tiff" / "test_image.tif"),
         ],
     )
+
     assert result.exit_code == 0
     assert "Replace ImageDescription" in result.output
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -101,3 +101,10 @@ def test_e2e_gui(
     client_response = client_future.result(timeout=0)
     assert client_response.status_code == 200
     assert "You chose" in client_response.text
+
+
+def test_e2e_version(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(main.imagedephi, ["--version"])
+
+    assert result.exit_code == 0
+    assert "ImageDePHI, version" in result.output


### PR DESCRIPTION
This adds a `--version` CLI option and an associated end-to-end test.

To support that option and future release workflows, it uses [setuptools-scm](https://pypi.org/project/setuptools-scm/) to set the version as distribution metadata.

setuptools-scm will look at the Git history, find the nearest tag, and dynamically compute a version number. Note, `setuptools-scm` also attempts to add all tracked Git files into the source distribution ("sdist"), so rigorous exclusions in `MANIFEST.in` are necessary to avoid bloat.