### PR TITLE
Handle case where previous output exists

### DIFF
--- a/imagedephi/gui.py
+++ b/imagedephi/gui.py
@@ -27,7 +27,6 @@ def select_directory(
     input_directory: Path = Path("/"),  # noqa: B008
     output_directory: Path = Path("/"),  # noqa: B008
 ):
-
     if not input_directory.is_dir():
         raise HTTPException(status_code=404, detail="Input directory not a directory")
     if not output_directory.is_dir():

--- a/imagedephi/main.py
+++ b/imagedephi/main.py
@@ -48,10 +48,17 @@ def imagedephi(ctx: click.Context, override_rules: TextIO | None) -> None:
     "output-dir",
     type=click.Path(exists=True, file_okay=False, readable=True, writable=True, path_type=Path),
 )
+@click.option(
+    "-o",
+    "--overwrite-existing-output",
+    is_flag=True,
+    default=False,
+    help="Overwrite previous output for input images",
+)
 @click.pass_obj
-def run(obj: ImagedephiContext, input_dir: Path, output_dir: Path):
+def run(obj: ImagedephiContext, input_dir: Path, output_dir: Path, overwrite_existing_output: bool):
     """Redact images in a folder according to given rule sets."""
-    redact_images(input_dir, output_dir, obj.override_rule_set)
+    redact_images(input_dir, output_dir, obj.override_rule_set, overwrite_existing_output)
 
 
 @imagedephi.command

--- a/imagedephi/redact.py
+++ b/imagedephi/redact.py
@@ -94,13 +94,6 @@ def _get_output_path(file_path: Path, output_dir: Path) -> Path:
     return output_dir / f"REDACTED_{file_path.name}"
 
 
-def get_base_rules():
-    base_rules_path = importlib.resources.files("imagedephi") / "base_rules.yaml"
-    with base_rules_path.open() as base_rules_stream:
-        base_rule_set = build_ruleset(yaml.safe_load(base_rules_stream), RuleSource.BASE)
-        return base_rule_set
-
-
 def _save_redacted_tiff(tiff_info: TiffInfo, output_path: Path, input_path: Path, overwrite: bool):
     if overwrite or not output_path.exists():
         if output_path.exists():
@@ -111,6 +104,13 @@ def _save_redacted_tiff(tiff_info: TiffInfo, output_path: Path, input_path: Path
             f"Could not redact {input_path.name}, existing redacted file in output directory. "
             "Use the --overwrite-existing-output flag to overwrite previously redacted files."
         )
+
+
+def get_base_rules():
+    base_rules_path = importlib.resources.files("imagedephi") / "base_rules.yaml"
+    with base_rules_path.open() as base_rules_stream:
+        base_rule_set = build_ruleset(yaml.safe_load(base_rules_stream), RuleSource.BASE)
+        return base_rule_set
 
 
 def redact_images(

--- a/imagedephi/redact.py
+++ b/imagedephi/redact.py
@@ -95,15 +95,16 @@ def _get_output_path(file_path: Path, output_dir: Path) -> Path:
 
 
 def _save_redacted_tiff(tiff_info: TiffInfo, output_path: Path, input_path: Path, overwrite: bool):
-    if overwrite or not output_path.exists():
-        if output_path.exists():
+    if output_path.exists():
+        if overwrite:
             click.echo(f"Found existing redaction for {input_path.name}. Overwriting...")
-        tifftools.write_tiff(tiff_info, output_path, allowExisting=True)
-    else:
-        click.echo(
-            f"Could not redact {input_path.name}, existing redacted file in output directory. "
-            "Use the --overwrite-existing-output flag to overwrite previously redacted files."
-        )
+        else:
+           click.echo(
+               f"Could not redact {input_path.name}, existing redacted file in output directory. "
+               "Use the --overwrite-existing-output flag to overwrite previously redacted files."
+           )
+           return
+    tifftools.write_tiff(tiff_info, output_path, allowExisting=True)
 
 
 def get_base_rules():

--- a/imagedephi/redact.py
+++ b/imagedephi/redact.py
@@ -99,11 +99,11 @@ def _save_redacted_tiff(tiff_info: TiffInfo, output_path: Path, input_path: Path
         if overwrite:
             click.echo(f"Found existing redaction for {input_path.name}. Overwriting...")
         else:
-           click.echo(
-               f"Could not redact {input_path.name}, existing redacted file in output directory. "
-               "Use the --overwrite-existing-output flag to overwrite previously redacted files."
-           )
-           return
+            click.echo(
+                f"Could not redact {input_path.name}, existing redacted file in output directory. "
+                "Use the --overwrite-existing-output flag to overwrite previously redacted files."
+            )
+            return
     tifftools.write_tiff(tiff_info, output_path, allowExisting=True)
 
 


### PR DESCRIPTION
Fixes #48 

A new flag has been added to the `run` command to allow overwriting existing output in the output directory.

Ex: `imagedephi run images/ output/ -o`

**Previous Behavior**
The `run` command would fail silently when attempting to write to an existing file.

**New Behavior**
Running `imagedephi run` without the new flag will not write over existing output images. For each image it cannot save due to existing files, it will print a message for the user informing them of what is happening.

Running `imagedephi run` with the new flag will overwrite existing redacted images, and also report to the user that it is doing so.