### PR TITLE
Reformat with black v23

### DIFF
--- a/imagedephi/gui.py
+++ b/imagedephi/gui.py
@@ -27,7 +27,6 @@ def select_directory(
     input_directory: Path = Path("/"),  # noqa: B008
     output_directory: Path = Path("/"),  # noqa: B008
 ):
-
     if not input_directory.is_dir():
         raise HTTPException(status_code=404, detail="Input directory not a directory")
     if not output_directory.is_dir():


### PR DESCRIPTION
Our CI started failing because Black cut a new release, which our code did not adhere to. 

Specifically, [this change](https://github.com/psf/black/pull/3035)

Now our code conforms to this new rule.