### PR TITLE
Prototype for type-checking rules

### DIFF
--- a/imagedephi/rules/rule.py
+++ b/imagedephi/rules/rule.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 from enum import Enum
-from typing import TypeVar
+from typing import Any, Type, TypeVar
 
 
 class RuleType(Enum):
@@ -14,6 +14,7 @@ class RedactMethod(Enum):
     REPLACE = "replace"
     DELETE = "delete"
     KEEP = "keep"
+    DATATYPE = "datatype"
 
 
 class FileFormat(Enum):
@@ -24,6 +25,22 @@ class FileFormat(Enum):
 class RuleSource(Enum):
     BASE = "base"
     OVERRIDE = "override"
+
+
+class ExpectedType(Enum):
+    NUMBER = "number"
+
+
+_expected_type_map: dict[ExpectedType, tuple[Type[Any]]] = {
+    ExpectedType.NUMBER: tuple([int, float]),
+}
+
+
+def is_expected_type(value: Any, expected_type: ExpectedType, expected_count: int) -> bool:
+    valid_types = _expected_type_map[expected_type]
+    if isinstance(value, list):
+        return len(value) == expected_count and all(isinstance(item, valid_types) for item in value)
+    return isinstance(value, valid_types)
 
 
 class Rule(abc.ABC):

--- a/imagedephi/rules/tiff.py
+++ b/imagedephi/rules/tiff.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import tifftools
 
-from .rule import MetadataRuleMixin, RedactMethod, Rule, RuleSource
+from .rule import ExpectedType, MetadataRuleMixin, RedactMethod, Rule, RuleSource, is_expected_type
 
 if TYPE_CHECKING:
     from tifftools.tifftools import IFD
@@ -72,6 +72,23 @@ class DeleteMetadataTiffRule(MetadataTiffRule):
 
     def apply(self, ifd: IFD):
         del ifd["tags"][self.tag.value]
+
+
+class DataTypeMetadataTiffRule(MetadataTiffRule):
+    redact_method = RedactMethod.DATATYPE
+    expected_type: ExpectedType
+    expected_count: int = 1
+
+    def __init__(self, rule_spec: dict, source: RuleSource) -> None:
+        super().__init__(rule_spec, source)
+        self.expected_type = rule_spec["expected_type"]
+        self.expected_count = rule_spec["expected_count"]
+
+    def apply(self, ifd: IFD):
+        if not is_expected_type(
+            ifd["tags"][self.tag.value]["data"], self.expected_type, self.expected_count
+        ):
+            del ifd["tags"][self.tag.value]
 
 
 class KeepMetadataTiffRule(MetadataTiffRule):

--- a/tests/override_rulesets/example_user_rules.yaml
+++ b/tests/override_rulesets/example_user_rules.yaml
@@ -1,0 +1,20 @@
+---
+name: Example user rules
+description: A set of reasonable rules used for testing
+rules:
+  tiff:
+    - description: Replace ImageDescription
+      tag_name: ImageDescription
+      method: replace
+      new_value: Redacted by ImageDePHI
+      type: metadata
+    - tag_name: YCbCrSubsampling
+      method: datatype
+      expected_type: number
+      expected_count: 2
+      type: metadata
+  svs:
+    - description: Delete ICC Profile
+      key_name: ICC Profile
+      type: metadata
+      method: delete


### PR DESCRIPTION
This PR introduces one possible way to incorporate type-checking into the redaction process. It adds a new rule type called `datatype`. Rules of this new type should always have a property called `expected_type`. In the example rules added in this PR, I've added one such rule with an `expected_type` of `number` (open to discussion of what they should be - should the allowed values here match the DataTypes defined in `tifftools`?)



