### PR TITLE
Don't use trailing slashes in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-recursive-include imagedephi/ *.yaml *.j2
+recursive-include imagedephi *.yaml *.j2
 
-prune tests/
+prune tests


### PR DESCRIPTION
This is causing error messages when building an sdist, and causing package data to not be bundled on Windows.

Fixes #69.