### PR TITLE
Launch the GUI when run directly from Windows Explorer

### DIFF
--- a/imagedephi/main.py
+++ b/imagedephi/main.py
@@ -14,8 +14,9 @@ import yaml
 from imagedephi.gui import app, shutdown_event
 from imagedephi.redact import redact_images, show_redaction_plan
 from imagedephi.rules import RuleSet, RuleSource, build_ruleset
-from imagedephi.utils.cli import run_coroutine
+from imagedephi.utils.cli import FallthroughGroup, run_coroutine
 from imagedephi.utils.network import unused_tcp_port, wait_for_port
+from imagedephi.utils.os import launched_from_windows_explorer
 
 
 @dataclass
@@ -23,7 +24,11 @@ class ImagedephiContext:
     override_rule_set: RuleSet | None = None
 
 
-@click.group
+@click.group(
+    cls=FallthroughGroup,
+    subcommand_name="gui",
+    should_fallthrough=launched_from_windows_explorer,
+)
 @click.option(
     "-r",
     "--override-rules",

--- a/imagedephi/utils/cli.py
+++ b/imagedephi/utils/cli.py
@@ -1,7 +1,9 @@
 import asyncio
 from collections.abc import Callable, Coroutine
 from functools import wraps
-from typing import ParamSpec, TypeVar
+from typing import Any, ParamSpec, TypeVar
+
+import click
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -15,3 +17,32 @@ def run_coroutine(f: Callable[P, Coroutine[None, None, T]]) -> Callable[P, T]:
         return asyncio.run(f(*args, **kwargs))
 
     return wrapper
+
+
+class FallthroughGroup(click.Group):
+    """A Group which may run a subcommand when no subcommand is specified."""
+
+    def __init__(self, subcommand_name: str, should_fallthrough: Callable[[], bool], **attrs: Any):
+        # Subcommands are not added until after this is instantiated,
+        # so only store the future subcommand name
+        self.subcommand_name = subcommand_name
+        self.should_fallthrough = should_fallthrough
+
+        attrs["invoke_without_command"] = True
+        attrs["no_args_is_help"] = False
+        super().__init__(**attrs)
+
+    def invoke(self, ctx: click.Context) -> Any:
+        # If no subcommand is specified.
+        # Use this test, since "ctx.invoked_subcommand" is not set yet.
+        if not ctx.protected_args:
+            if self.should_fallthrough():
+                # Subcommands are stored in "ctx.protected_args", so fake a call by prepending it
+                # Calling "ctx.invoke" directly here would not allow the parent command to run
+                ctx.protected_args.insert(0, self.subcommand_name)
+            elif not ctx.resilient_parsing:
+                # Execute the normal Click "no_args_is_help" behavior
+                click.echo(ctx.get_help(), color=ctx.color)
+                ctx.exit()
+        # All non-help cases reach here
+        return super().invoke(ctx)

--- a/imagedephi/utils/os.py
+++ b/imagedephi/utils/os.py
@@ -1,0 +1,40 @@
+import ctypes
+import sys
+
+import click
+
+
+def launched_from_frozen_binary() -> bool:
+    """Return whether the current program was launched within a frozen binary."""
+    # https://pyinstaller.org/en/stable/runtime-information.html#run-time-information
+    return getattr(sys, "frozen", False)
+
+
+def launched_from_windows_explorer() -> bool:
+    """Return whether the current program was launched directly from the Windows Explorer."""
+    # Using "platform.system()" is preferred: https://stackoverflow.com/a/58071295
+    # However, this is not recognised by Mypy yet: https://github.com/python/mypy/issues/8166
+    if sys.platform == "win32":
+        # See https://devblogs.microsoft.com/oldnewthing/20160125-00/?p=92922 for this algorithm.
+        # Contradicting the blog, the API docs
+        # https://learn.microsoft.com/en-us/windows/console/getconsoleprocesslist
+        # indicate that the "process_list" array may not be null.
+        # Also "process_list" must have a size larger than 0, but its full content isn't needed.
+        process_list_size = 1
+        # Array elements should be DWORD, which is a uint
+        process_list = (ctypes.c_uint * process_list_size)()
+        process_count: int = ctypes.windll.kernel32.GetConsoleProcessList(
+            process_list, process_list_size
+        )
+        if process_count == 0:
+            # TODO: Change this to be logged internally, as it's not actionable by end users.
+            click.echo("Could not detect Windows console.", err=True)
+            # Assume it's not Explorer, to be conservative
+            return False
+        else:
+            # If frozen, the Pyinstaller bootloader is also running in this console:
+            # https://pyinstaller.org/en/stable/advanced-topics.html#the-bootstrap-process-in-detail
+            expected_solo_process_count = 2 if launched_from_frozen_binary() else 1
+            return process_count == expected_solo_process_count
+    else:
+        return False

--- a/imagedephi/utils/os.py
+++ b/imagedephi/utils/os.py
@@ -1,8 +1,6 @@
 import ctypes
 import sys
 
-import click
-
 
 def launched_from_frozen_binary() -> bool:
     """Return whether the current program was launched within a frozen binary."""
@@ -27,14 +25,11 @@ def launched_from_windows_explorer() -> bool:
             process_list, process_list_size
         )
         if process_count == 0:
-            # TODO: Change this to be logged internally, as it's not actionable by end users.
-            click.echo("Could not detect Windows console.", err=True)
-            # Assume it's not Explorer, to be conservative
-            return False
-        else:
-            # If frozen, the Pyinstaller bootloader is also running in this console:
-            # https://pyinstaller.org/en/stable/advanced-topics.html#the-bootstrap-process-in-detail
-            expected_solo_process_count = 2 if launched_from_frozen_binary() else 1
-            return process_count == expected_solo_process_count
+            # TODO: Log this internally
+            raise OSError("Could not detect Windows console.")
+        # If frozen, the Pyinstaller bootloader is also running in this console:
+        # https://pyinstaller.org/en/stable/advanced-topics.html#the-bootstrap-process-in-detail
+        expected_solo_process_count = 2 if launched_from_frozen_binary() else 1
+        return process_count == expected_solo_process_count
     else:
         return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,14 @@
 from pathlib import Path
 
+from click.testing import CliRunner
 import pytest
 
 
 @pytest.fixture
 def data_dir() -> Path:
     return Path(__file__).with_name("data")
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    return CliRunner()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -13,11 +13,6 @@ from imagedephi.utils.network import wait_for_port
 
 
 @pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
-@pytest.fixture
 def thread_executor() -> Generator[ThreadPoolExecutor, None, None]:
     executor = ThreadPoolExecutor(max_workers=1)
     yield executor
@@ -25,8 +20,8 @@ def thread_executor() -> Generator[ThreadPoolExecutor, None, None]:
 
 
 @pytest.mark.timeout(5)
-def test_e2e_run(runner: CliRunner, data_dir: Path, tmp_path: Path) -> None:
-    result = runner.invoke(
+def test_e2e_run(cli_runner: CliRunner, data_dir: Path, tmp_path: Path) -> None:
+    result = cli_runner.invoke(
         main.imagedephi,
         [
             "--override-rules",
@@ -45,8 +40,8 @@ def test_e2e_run(runner: CliRunner, data_dir: Path, tmp_path: Path) -> None:
 
 
 @pytest.mark.timeout(5)
-def test_e2e_plan(runner: CliRunner, data_dir: Path) -> None:
-    result = runner.invoke(
+def test_e2e_plan(cli_runner: CliRunner, data_dir: Path) -> None:
+    result = cli_runner.invoke(
         main.imagedephi,
         [
             "--override-rules",
@@ -56,12 +51,12 @@ def test_e2e_plan(runner: CliRunner, data_dir: Path) -> None:
         ],
     )
     assert result.exit_code == 0
-    assert "Replace ImageDescription" in result.stdout
+    assert "Replace ImageDescription" in result.output
 
 
 @pytest.mark.timeout(5)
 def test_e2e_gui(
-    runner: CliRunner,
+    cli_runner: CliRunner,
     unused_tcp_port: int,
     data_dir: Path,
     tmp_path: Path,
@@ -93,7 +88,7 @@ def test_e2e_gui(
     # we'll break that expection here.
     client_future = thread_executor.submit(client_select_directory, unused_tcp_port)
 
-    cli_result = runner.invoke(main.imagedephi, ["gui", "--port", str(unused_tcp_port)])
+    cli_result = cli_runner.invoke(main.imagedephi, ["gui", "--port", str(unused_tcp_port)])
 
     assert cli_result.exit_code == 0
     webbrowser_open_mock.assert_called_once()

--- a/tests/test_utils_cli.py
+++ b/tests/test_utils_cli.py
@@ -1,8 +1,10 @@
 from inspect import iscoroutinefunction
 
+import click
+from click.testing import CliRunner
 from pytest_mock import MockerFixture
 
-from imagedephi.utils.cli import run_coroutine
+from imagedephi.utils.cli import FallthroughGroup, run_coroutine
 
 
 def test_utils_cli_run_coroutine(mocker: MockerFixture) -> None:
@@ -13,3 +15,54 @@ def test_utils_cli_run_coroutine(mocker: MockerFixture) -> None:
     assert not iscoroutinefunction(wrapped)
     wrapped(5, foo="bar")
     async_mock.assert_awaited_once_with(5, foo="bar")
+
+
+def test_utils_cli_fallthrough_group_baseline(mocker: MockerFixture, cli_runner: CliRunner) -> None:
+    cmd = mocker.Mock()
+    sub = mocker.Mock()
+    should_fallthrough = mocker.Mock()
+    # Decorators can't be used with mocks, so create the group and subcommands here
+    cmd_group = FallthroughGroup(
+        subcommand_name="sub", should_fallthrough=should_fallthrough, callback=cmd
+    )
+    cmd_group.add_command(click.Command(name="sub", callback=sub))
+
+    result = cli_runner.invoke(cmd_group, ["sub"])
+
+    assert result.exit_code == 0
+    cmd.assert_called_once()
+    sub.assert_called_once()
+    should_fallthrough.assert_not_called()
+    assert "Usage" not in result.output
+
+
+def test_utils_cli_fallthrough_group_false(mocker: MockerFixture, cli_runner: CliRunner) -> None:
+    cmd = mocker.Mock()
+    sub = mocker.Mock()
+    cmd_group = FallthroughGroup(
+        subcommand_name="sub", should_fallthrough=lambda: False, callback=cmd
+    )
+    cmd_group.add_command(click.Command(name="sub", callback=sub))
+
+    result = cli_runner.invoke(cmd_group, [])
+
+    assert result.exit_code == 0
+    cmd.assert_not_called()
+    sub.assert_not_called()
+    assert "Usage" in result.output
+
+
+def test_utils_cli_fallthrough_group_true(mocker: MockerFixture, cli_runner: CliRunner) -> None:
+    cmd = mocker.Mock()
+    sub = mocker.Mock()
+    cmd_group = FallthroughGroup(
+        subcommand_name="sub", should_fallthrough=lambda: True, callback=cmd
+    )
+    cmd_group.add_command(click.Command(name="sub", callback=sub))
+
+    result = cli_runner.invoke(cmd_group, [])
+
+    assert result.exit_code == 0
+    cmd.assert_called_once()
+    sub.assert_called_once()
+    assert "Usage" not in result.output

--- a/tests/test_utils_os.py
+++ b/tests/test_utils_os.py
@@ -1,0 +1,44 @@
+import sys
+
+import pytest
+from pytest_mock import MockerFixture
+
+from imagedephi.utils.os import launched_from_frozen_binary, launched_from_windows_explorer
+
+
+@pytest.mark.parametrize("frozen", [False, True])
+def test_utils_os_launched_from_frozen_binary(frozen: bool, mocker: MockerFixture) -> None:
+    mocker.patch("sys.frozen", new=frozen, create=True)
+
+    result = launched_from_frozen_binary()
+
+    assert result is frozen
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="non-windows only")
+def test_utils_os_launched_from_windows_explorer_nonwindows() -> None:
+    result = launched_from_windows_explorer()
+
+    assert result is False
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="windows only")
+@pytest.mark.parametrize(
+    "frozen,process_count,expected",
+    [
+        (False, 1, True),
+        (False, 3, False),
+        (True, 2, True),
+        (True, 3, False),
+    ],
+    ids=["non-frozen explorer", "non-frozen console", "frozen explorer", "frozen console"],
+)
+def test_utils_os_launched_from_windows_explorer_windows(
+    frozen: bool, process_count: int, expected: bool, mocker: MockerFixture
+) -> None:
+    mocker.patch("imagedephi.utils.os.launched_from_frozen_binary", return_value=frozen)
+    mocker.patch("ctypes.windll.kernel32.GetConsoleProcessList", return_value=process_count)
+
+    result = launched_from_windows_explorer()
+
+    assert result is expected


### PR DESCRIPTION
On Windows, this will cause the ImageDePHI GUI to start when a user runs `imagedephi.exe` directly from Windows Explorer. In all other cases (non-Windows and Windows CLI usage), the existing behavior (running with no arguments prints help text) is unchanged.

This is implemented via a new `FallthroughGroup` subclass of `click.Group`. This implementation abstracts the logic of falling through out of the main CLI endpoints (which are more concerned with handling arguments). The decoupled `FallthroughGroup` is also easier to test.

A new `launched_from_windows_explorer` utility uses Windows platform APIs to determine whether the current ImageDePHI process is running via a Windows command line shell or was launched directly by Windows Explorer. See code comments for implementation details.