### PR TITLE
Create output file

### DIFF
--- a/imagedephi/main.py
+++ b/imagedephi/main.py
@@ -64,19 +64,20 @@ def imagedephi(ctx: click.Context, override_rules: TextIO | None) -> None:
     default=Path('.'),
     type=click.Path(exists=True, file_okay=False, readable=True, writable=True, path_type=Path),
 )
-@click.option(
-    "-o",
-    "--overwrite-existing-output",
-    is_flag=True,
-    default=False,
-    help="Overwrite previous output for input images.",
-)
+# I don't think we need this anymore
+# @click.option(
+#     "-o",
+#     "--overwrite-existing-output",
+#     is_flag=True,
+#     default=False,
+#     help="Overwrite previous output for input images",
+# )
 @click.pass_obj
 def run(
-    obj: ImagedephiContext, input_path: Path, output_dir: Path, overwrite_existing_output: bool
+    obj: ImagedephiContext, input_path: Path, output_dir: Path
 ):
     """Perform the redaction of images."""
-    redact_images(input_path, output_dir, obj.override_rule_set, overwrite_existing_output)
+    redact_images(input_path, output_dir, obj.override_rule_set)
 
 
 @imagedephi.command

--- a/imagedephi/main.py
+++ b/imagedephi/main.py
@@ -58,10 +58,12 @@ def imagedephi(ctx: click.Context, override_rules: TextIO | None) -> None:
 
 @imagedephi.command
 @click.argument("input-path", type=click.Path(exists=True, readable=True, path_type=Path))
-@click.argument(
-    "output-dir",
-    required=False,
-    default=Path("."),
+@click.option(
+    "-o",
+    "--output-dir",
+    default=Path.cwd(),
+    show_default="current working directory",
+    help="Path where output directory will be created.",
     type=click.Path(exists=True, file_okay=False, readable=True, writable=True, path_type=Path),
 )
 @click.pass_obj

--- a/imagedephi/main.py
+++ b/imagedephi/main.py
@@ -61,21 +61,11 @@ def imagedephi(ctx: click.Context, override_rules: TextIO | None) -> None:
 @click.argument(
     "output-dir",
     required=False,
-    default=Path('.'),
+    default=Path("."),
     type=click.Path(exists=True, file_okay=False, readable=True, writable=True, path_type=Path),
 )
-# I don't think we need this anymore
-# @click.option(
-#     "-o",
-#     "--overwrite-existing-output",
-#     is_flag=True,
-#     default=False,
-#     help="Overwrite previous output for input images",
-# )
 @click.pass_obj
-def run(
-    obj: ImagedephiContext, input_path: Path, output_dir: Path
-):
+def run(obj: ImagedephiContext, input_path: Path, output_dir: Path):
     """Perform the redaction of images."""
     redact_images(input_path, output_dir, obj.override_rule_set)
 

--- a/imagedephi/main.py
+++ b/imagedephi/main.py
@@ -60,6 +60,8 @@ def imagedephi(ctx: click.Context, override_rules: TextIO | None) -> None:
 @click.argument("input-path", type=click.Path(exists=True, readable=True, path_type=Path))
 @click.argument(
     "output-dir",
+    required=False,
+    default=Path('.'),
     type=click.Path(exists=True, file_okay=False, readable=True, writable=True, path_type=Path),
 )
 @click.option(

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -25,7 +25,7 @@ def _get_output_path(file_path: Path, output_dir: Path) -> Path:
     return output_dir / f"REDACTED_{file_path.name}"
 
 
-def _save_redacted_tiff(tiff_info: TiffInfo, output_path: Path, input_path: Path, overwrite: bool):
+def _save_redacted_tiff(tiff_info: TiffInfo, output_path: Path):
     tifftools.write_tiff(tiff_info, output_path, allowExisting=True)
 
 
@@ -51,7 +51,6 @@ def redact_images(
     input_path: Path,
     output_dir: Path,
     override_rules: RuleSet | None = None,
-    overwrite: bool = False,
 ) -> None:
     base_rules = get_base_rules()
     images_to_redact = iter_image_files(input_path) if input_path.is_dir() else [input_path]
@@ -82,7 +81,7 @@ def redact_images(
         else:
             redaction_plan.execute_plan()
             output_path = _get_output_path(image_file, redact_dir)
-            _save_redacted_tiff(redaction_plan.get_image_data(), output_path, image_file, overwrite)
+            _save_redacted_tiff(redaction_plan.get_image_data(), output_path)
 
 
 def show_redaction_plan(input_path: Path, override_rules: RuleSet | None = None) -> None:

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -4,7 +4,6 @@ from collections.abc import Generator
 import datetime
 import importlib.resources
 from pathlib import Path
-import re
 from typing import TYPE_CHECKING
 
 import click
@@ -57,10 +56,6 @@ def redact_images(
     images_to_redact = iter_image_files(input_path) if input_path.is_dir() else [input_path]
     time_stamp = datetime.datetime.now().isoformat(timespec="seconds")
     redact_dir = Path(f"{output_dir}/Redacted_{time_stamp}")
-    x = re.match(r"Redacted\_\d{4}\-\d{2}\-\d{2}[T]\d{2}\:\d{2}\:\d{2}", redact_dir.name)
-    test = re.compile(r"Redacted\_\d{4}\-\d{2}\-\d{2}[T]\d{2}\:\d{2}\:\d{2}")
-    print(test)
-    print(x)
     try:
         redact_dir.mkdir(parents=True)
     except PermissionError:

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -56,7 +56,10 @@ def redact_images(
     images_to_redact = iter_image_files(input_path) if input_path.is_dir() else [input_path]
     time_stamp = datetime.datetime.now().isoformat(timespec="seconds")
     redact_dir = Path(f"{output_dir}/Redacted_{time_stamp}")
-    redact_dir.mkdir(parents=True)
+    try:
+        redact_dir.mkdir(parents=True)
+    except PermissionError:
+        "Cannnot create an output directory, permission error."
     click.echo(f"Created redaction folder: {redact_dir}")
     for image_file in images_to_redact:
         if image_file.suffix not in FILE_EXTENSION_MAP:

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 import datetime
 import importlib.resources
 from pathlib import Path
+import re
 from typing import TYPE_CHECKING
 
 import click
@@ -56,6 +57,10 @@ def redact_images(
     images_to_redact = iter_image_files(input_path) if input_path.is_dir() else [input_path]
     time_stamp = datetime.datetime.now().isoformat(timespec="seconds")
     redact_dir = Path(f"{output_dir}/Redacted_{time_stamp}")
+    x = re.match(r"Redacted\_\d{4}\-\d{2}\-\d{2}[T]\d{2}\:\d{2}\:\d{2}", redact_dir.name)
+    test = re.compile(r"Redacted\_\d{4}\-\d{2}\-\d{2}[T]\d{2}\:\d{2}\:\d{2}")
+    print(test)
+    print(x)
     try:
         redact_dir.mkdir(parents=True)
     except PermissionError:

--- a/imagedephi/templates/DirectorySelector.html.j2
+++ b/imagedephi/templates/DirectorySelector.html.j2
@@ -8,10 +8,10 @@
     <script defer
             src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/@mdi/font@7.1.96/css/materialdesignicons.min.css"
-          rel="stylesheet" />
+          rel="stylesheet"/>
     <link href="https://cdn.jsdelivr.net/npm/daisyui@2.47.0/dist/full.css"
           rel="stylesheet"
-          type="text/css" />
+          type="text/css"/>
   </head>
   <body class="bg-base-300 flex justify-center min-h-screen">
     <div class="card bg-base-200 w-2/5 m-8">
@@ -21,10 +21,10 @@
           <form method="post" action="{{ url_for('redact') }}">
             <input type="hidden"
                    value="{{ input_directory_data.directory }}"
-                   name="input_directory" />
+                   name="input_directory"/>
             <input type="hidden"
                    value="{{ output_directory_data.directory }}"
-                   name="output_directory" />
+                   name="output_directory"/>
             <button type="submit" class="btn btn-primary btn-active">Select Current Directories</button>
           </form>
         </div>

--- a/imagedephi/templates/DirectorySelector.html.j2
+++ b/imagedephi/templates/DirectorySelector.html.j2
@@ -8,10 +8,10 @@
     <script defer
             src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/@mdi/font@7.1.96/css/materialdesignicons.min.css"
-          rel="stylesheet"/>
+          rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/daisyui@2.47.0/dist/full.css"
           rel="stylesheet"
-          type="text/css"/>
+          type="text/css" />
   </head>
   <body class="bg-base-300 flex justify-center min-h-screen">
     <div class="card bg-base-200 w-2/5 m-8">
@@ -21,10 +21,10 @@
           <form method="post" action="{{ url_for('redact') }}">
             <input type="hidden"
                    value="{{ input_directory_data.directory }}"
-                   name="input_directory"/>
+                   name="input_directory" />
             <input type="hidden"
                    value="{{ output_directory_data.directory }}"
-                   name="output_directory"/>
+                   name="output_directory" />
             <button type="submit" class="btn btn-primary btn-active">Select Current Directories</button>
           </form>
         </div>

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -30,6 +30,7 @@ def test_e2e_run(cli_runner: CliRunner, data_dir: Path, tmp_path: Path) -> None:
             str(data_dir / "rules" / "example_user_rules.yml"),
             "run",
             str(data_dir / "input" / "tiff"),
+            "--output-dir",
             str(tmp_path),
         ],
     )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,8 +1,8 @@
 import asyncio
 from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor
-import datetime
 from pathlib import Path
+import re
 import sys
 
 from click.testing import CliRunner
@@ -36,11 +36,12 @@ def test_e2e_run(cli_runner: CliRunner, data_dir: Path, tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    time_stamp = datetime.datetime.now().isoformat(timespec="seconds")
-    output_file = tmp_path / f"Redacted_{time_stamp}/REDACTED_test_image.tif"
-    output_file_bytes = output_file.read_bytes()
-    assert b"large_image_converter" not in output_file_bytes
-    assert b"Redacted by ImageDePHI" in output_file_bytes
+    for x in tmp_path.iterdir():
+        if re.match(r"Redacted\_\d{4}\-\d{2}\-\d{2}[T]\d{2}\:\d{2}\:\d{2}", x.name):
+            for y in x.iterdir():
+                output_file_bytes = y.read_bytes()
+                assert b"large_image_converter" not in output_file_bytes
+                assert b"Redacted by ImageDePHI" in output_file_bytes
 
 
 @pytest.mark.timeout(5)
@@ -97,10 +98,11 @@ def test_e2e_gui(
 
     assert cli_result.exit_code == 0
     webbrowser_open_mock.assert_called_once()
-    time_stamp = datetime.datetime.now().isoformat(timespec="seconds")
-    output_file = tmp_path / f"Redacted_{time_stamp}/REDACTED_test_image.tif"
-    output_file_bytes = output_file.read_bytes()
-    assert b"large_image_converter" not in output_file_bytes
+    for x in tmp_path.iterdir():
+        if re.match(r"Redacted\_\d{4}\-\d{2}\-\d{2}[T]\d{2}\:\d{2}\:\d{2}", x.name):
+            for y in x.iterdir():
+                output_file_bytes = y.read_bytes()
+                assert b"large_image_converter" not in output_file_bytes
     assert f"127.0.0.1:{unused_tcp_port}" in webbrowser_open_mock.call_args.args[0]
     # Expect the client thread to be completed
     client_response = client_future.result(timeout=0)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,6 +1,7 @@
 import asyncio
 from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor
+import datetime
 from pathlib import Path
 import sys
 
@@ -34,7 +35,8 @@ def test_e2e_run(cli_runner: CliRunner, data_dir: Path, tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0
-    output_file = tmp_path / "REDACTED_test_image.tif"
+    time_stamp = datetime.datetime.now().isoformat(timespec="seconds")
+    output_file = tmp_path / f"Redacted_{time_stamp}/REDACTED_test_image.tif"
     assert output_file.exists()
     output_file_bytes = output_file.read_bytes()
     assert b"large_image_converter" not in output_file_bytes
@@ -95,7 +97,8 @@ def test_e2e_gui(
 
     assert cli_result.exit_code == 0
     webbrowser_open_mock.assert_called_once()
-    output_file = tmp_path / "REDACTED_test_image.tif"
+    time_stamp = datetime.datetime.now().isoformat(timespec="seconds")
+    output_file = tmp_path / f"Redacted_{time_stamp}/REDACTED_test_image.tif"
     assert output_file.exists()
     output_file_bytes = output_file.read_bytes()
     assert b"large_image_converter" not in output_file_bytes

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -38,7 +38,6 @@ def test_e2e_run(cli_runner: CliRunner, data_dir: Path, tmp_path: Path) -> None:
     assert result.exit_code == 0
     time_stamp = datetime.datetime.now().isoformat(timespec="seconds")
     output_file = tmp_path / f"Redacted_{time_stamp}/REDACTED_test_image.tif"
-    assert output_file.exists()
     output_file_bytes = output_file.read_bytes()
     assert b"large_image_converter" not in output_file_bytes
     assert b"Redacted by ImageDePHI" in output_file_bytes
@@ -100,7 +99,6 @@ def test_e2e_gui(
     webbrowser_open_mock.assert_called_once()
     time_stamp = datetime.datetime.now().isoformat(timespec="seconds")
     output_file = tmp_path / f"Redacted_{time_stamp}/REDACTED_test_image.tif"
-    assert output_file.exists()
     output_file_bytes = output_file.read_bytes()
     assert b"large_image_converter" not in output_file_bytes
     assert f"127.0.0.1:{unused_tcp_port}" in webbrowser_open_mock.call_args.args[0]

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -1,3 +1,4 @@
+import datetime
 from pathlib import Path, PurePath
 
 import pytest
@@ -25,7 +26,8 @@ def svs_input_path(data_dir, request) -> Path:
 def test_redact_svs(svs_input_path, tmp_path, override_rule_set):
     redact.redact_images(svs_input_path, tmp_path, override_rule_set)
 
-    svs_output_file = tmp_path / "REDACTED_test_svs_image_blank.svs"
+    time_stamp = datetime.datetime.now().isoformat(timespec="seconds")
+    svs_output_file = tmp_path / f"Redacted_{time_stamp}/REDACTED_test_svs_image_blank.svs"
     assert svs_output_file.exists()
     svs_output_file_bytes = svs_output_file.read_bytes()
     # verify our custom svs rule was applied

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -1,5 +1,5 @@
-import datetime
 from pathlib import Path, PurePath
+import re
 
 import pytest
 import yaml
@@ -26,12 +26,12 @@ def svs_input_path(data_dir, request) -> Path:
 def test_redact_svs(svs_input_path, tmp_path, override_rule_set):
     redact.redact_images(svs_input_path, tmp_path, override_rule_set)
 
-    time_stamp = datetime.datetime.now().isoformat(timespec="seconds")
-    svs_output_file = tmp_path / f"Redacted_{time_stamp}/REDACTED_test_svs_image_blank.svs"
-    assert svs_output_file.exists()
-    svs_output_file_bytes = svs_output_file.read_bytes()
-    # verify our custom svs rule was applied
-    assert b"ICC Profile" not in svs_output_file_bytes
+    for x in tmp_path.iterdir():
+        if re.match(r"Redacted\_\d{4}\-\d{2}\-\d{2}[T]\d{2}\:\d{2}\:\d{2}", x.name):
+            for y in x.iterdir():
+                svs_output_file_bytes = y.read_bytes()
+                # verify our custom svs rule was applied
+                assert b"ICC Profile" not in svs_output_file_bytes
 
 
 def test_plan_svs(capsys, svs_input_path, override_rule_set):


### PR DESCRIPTION
- Makes `output_dir` flag optional
- Removes overwrite flag
- Creates a new directory at the supplied `output_dir` named `Redacted_[time_stamp]` and places redacted images inside. 
- Defaults to current directory if no `output_dir` is given.

Closes #48 Closes #72