### PR TITLE
Simplify template URL creation

### DIFF
--- a/imagedephi/templates/BaseSelectorWidget.html.j2
+++ b/imagedephi/templates/BaseSelectorWidget.html.j2
@@ -12,7 +12,7 @@
           <span class="font-black">{{ ancestor_name }}</span>
         {% else %}
           <a class="text-blue-700"
-             href="{{- url_for('select_directory') -}}?{%- block selector_ancestor_query scoped required -%}{%- endblock selector_ancestor_query -%}">
+             href="{%- block selector_ancestor_url scoped required -%}{%- endblock selector_ancestor_url -%}">
             {{ ancestor_name }}
           </a>
         {% endif %}
@@ -23,7 +23,7 @@
 <ul>
   {% for child_directory in directory_data.child_directories|sort %}
     {# Put the <a> outside, to make the whole line clickable #}
-    <a href="{{- url_for('select_directory') -}}?{%- block selector_child_directory_query scoped required -%}{%- endblock selector_child_directory_query -%}">
+    <a href="{%- block selector_child_directory_url scoped required -%}{%- endblock selector_child_directory_url -%}">
       <li class="hover:bg-base-300">
         <i class="mdi mdi-folder"></i>
         {{ child_directory.name }}

--- a/imagedephi/templates/InputSelectorWidget.html.j2
+++ b/imagedephi/templates/InputSelectorWidget.html.j2
@@ -3,9 +3,9 @@
 {% block selector_title %}
   Input Directory
 {% endblock selector_title %}
-{% block selector_ancestor_query -%}
-  input_directory={{ ancestor|urlencode }}&output_directory={{ output_directory_data.directory|urlencode }}
-{%- endblock selector_ancestor_query %}
-{% block selector_child_directory_query -%}
-  input_directory={{ child_directory|urlencode }}&output_directory={{ output_directory_data.directory|urlencode }}
-{%- endblock selector_child_directory_query %}
+{% block selector_ancestor_url -%}
+  {{ request.url.include_query_params(input_directory=ancestor) }}
+{%- endblock selector_ancestor_url %}
+{% block selector_child_directory_url -%}
+  {{ request.url.include_query_params(input_directory=child_directory) }}
+{%- endblock selector_child_directory_url %}

--- a/imagedephi/templates/OutputSelectorWidget.html.j2
+++ b/imagedephi/templates/OutputSelectorWidget.html.j2
@@ -3,9 +3,9 @@
 {% block selector_title %}
   Output Directory
 {% endblock selector_title %}
-{% block selector_ancestor_query -%}
-  input_directory={{ input_directory_data.directory|urlencode }}&output_directory={{ ancestor|urlencode }}
-{%- endblock selector_ancestor_query %}
-{% block selector_child_directory_query -%}
-  input_directory={{ input_directory_data.directory|urlencode }}&output_directory={{ child_directory|urlencode }}
-{%- endblock selector_child_directory_query %}
+{% block selector_ancestor_url -%}
+  {{ request.url.include_query_params(output_directory=ancestor) }}
+{%- endblock selector_ancestor_url %}
+{% block selector_child_directory_url -%}
+  {{ request.url.include_query_params(output_directory=child_directory) }}
+{%- endblock selector_child_directory_url %}


### PR DESCRIPTION
In the template context `request.url` returns [a `URL` object](https://www.starlette.io/requests/#url), which contains all the query parameters of the current endpoint. By calling `URL.include_query_params`, it's possible to selectively overwrite only the query parameters which need to change. This also has the advantage of internally handling URL encoding, so we don't have to manually assemble a query string.