### PR TITLE
Add an endpoint to initialize the GUI

### DIFF
--- a/imagedephi/main.py
+++ b/imagedephi/main.py
@@ -8,6 +8,7 @@ from typing import TextIO
 import webbrowser
 
 import click
+from fastapi.datastructures import URL
 from hypercorn import Config
 from hypercorn.asyncio import serve
 import yaml
@@ -106,9 +107,11 @@ async def gui(port: int) -> None:
         # To avoid race conditions, ensure that the webserver is
         # actually running before launching the browser
         await wait_for_port(port)
-        url = f"http://{host}:{port}/"
-        click.echo(f"Server is running at {url} .")
-        webbrowser.open(url)
+        home_url = app.url_path_for("home").make_absolute_url(
+            URL(scheme="http", netloc=f"{host}:{port}")
+        )
+        click.echo(f"Server is running at {home_url} .")
+        webbrowser.open(str(home_url))
 
     async with asyncio.TaskGroup() as task_group:
         task_group.create_task(announce_ready())

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -11,8 +11,8 @@ def client() -> TestClient:
     return TestClient(app)
 
 
-def test_gui_select_directory(client: TestClient) -> None:
-    response = client.get("/")
+def test_gui_home(client: TestClient) -> None:
+    response = client.get(app.url_path_for("home"), follow_redirects=True)
 
     assert response.status_code == 200
     assert "Select Directory" in response.text
@@ -35,7 +35,8 @@ def test_gui_select_directory_input_not_found(
     tmp_path: Path,
 ) -> None:
     response = client.get(
-        app.url_path_for("select_directory"), params={"input_directory": str(tmp_path / "fake")}
+        app.url_path_for("select_directory"),
+        params={"input_directory": str(tmp_path / "fake"), "output_directory": str(tmp_path)},
     )
 
     assert response.status_code == 404
@@ -47,7 +48,8 @@ def test_gui_select_directory_output_not_found(
     tmp_path: Path,
 ) -> None:
     response = client.get(
-        app.url_path_for("select_directory"), params={"output_directory": str(tmp_path / "fake")}
+        app.url_path_for("select_directory"),
+        params={"input_directory": str(tmp_path), "output_directory": str(tmp_path / "fake")},
     )
 
     assert response.status_code == 404


### PR DESCRIPTION
This should improve how we handle default directories on Windows. It also provides a better separation of concerns (GUI initialization vs actual directory selection), which should make future development and testing easier.

Fixes #59.