### PR TITLE
Rename redaction classes

### DIFF
--- a/imagedephi/redact/build_redaction_plan.py
+++ b/imagedephi/redact/build_redaction_plan.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from imagedephi.rules import FileFormat, Ruleset
 
 from .redaction_plan import RedactionPlan
-from .svs import SvsMetadataRedactionPlan
-from .tiff import TiffMetadataRedactionPlan
+from .svs import SvsRedactionPlan
+from .tiff import TiffRedactionPlan
 
 FILE_EXTENSION_MAP: dict[str, FileFormat] = {
     ".tif": FileFormat.TIFF,
@@ -22,13 +22,13 @@ def build_redaction_plan(
         if override_rules:
             merged_rules.metadata.update(override_rules.tiff.metadata)
 
-        return TiffMetadataRedactionPlan(image_path, merged_rules)
+        return TiffRedactionPlan(image_path, merged_rules)
     elif file_extension == FileFormat.SVS:
         merged_rules = base_rules.svs.copy()
         if override_rules:
             merged_rules.metadata.update(override_rules.svs.metadata)
             merged_rules.image_description.update(override_rules.svs.image_description)
 
-        return SvsMetadataRedactionPlan(image_path, merged_rules)
+        return SvsRedactionPlan(image_path, merged_rules)
     else:
         raise Exception(f"File format for {image_path} not supported.")

--- a/imagedephi/redact/svs.py
+++ b/imagedephi/redact/svs.py
@@ -8,7 +8,7 @@ import tifftools.constants
 
 from imagedephi.rules import ConcreteMetadataRule, FileFormat, SvsRules
 
-from .tiff import TiffMetadataRedactionPlan
+from .tiff import TiffRedactionPlan
 
 if TYPE_CHECKING:
     from tifftools.tifftools import IFD
@@ -41,7 +41,7 @@ class MalformedAperioFileError(Exception):
     ...
 
 
-class SvsMetadataRedactionPlan(TiffMetadataRedactionPlan):
+class SvsRedactionPlan(TiffRedactionPlan):
     """
     Represents a plan of action for redacting files in Aperio (.svs) format.
 

--- a/imagedephi/redact/tiff.py
+++ b/imagedephi/redact/tiff.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from tifftools.tifftools import IFD, TiffInfo
 
 
-class TiffMetadataRedactionPlan(RedactionPlan):
+class TiffRedactionPlan(RedactionPlan):
     """
     Represents a plan of action for redacting metadata from TIFF images.
 
@@ -48,7 +48,7 @@ class TiffMetadataRedactionPlan(RedactionPlan):
                     # entry['ifds'] contains a list of lists
                     # see tifftools.read_tiff
                     for sub_ifds in entry.get("ifds", []):
-                        yield from TiffMetadataRedactionPlan._iter_tiff_tag_entries(
+                        yield from TiffRedactionPlan._iter_tiff_tag_entries(
                             sub_ifds, tag.get("tagset")
                         )
 


### PR DESCRIPTION
Redaction classes will handle both metadata and image redaction (#102), so the names `TiffMetadataRedactionPlan` and `SvsMetadataRedactionPlan` were not appropriate.