### PR TITLE
Don't commit Redacted images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Redacted Images
+*/REDACTED_*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -127,6 +130,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# Redacted Images
-*/REDACTED_*

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Redacted Images
+*/REDACTED_*


### PR DESCRIPTION
Adding to gitignore so we don't accidentally commit images redacted while testing.