### PR TITLE
Cover additional image description keys

### DIFF
--- a/imagedephi/base_rules.yaml
+++ b/imagedephi/base_rules.yaml
@@ -789,3 +789,15 @@ svs:
       action: delete
     Webslide Files:
       action: delete
+    CalibrationAverageBlue:
+      action: keep
+    CalibrationAverageGreen:
+      action: keep
+    CalibrationAverageRed:
+      action: keep
+    ScannerType:
+      action: delete
+    SessionMode:
+      action: delete
+    Scan Warning:
+      action: delete


### PR DESCRIPTION
Fix #114 

Cover SVS image description metadata that can be generated by Leica G450 scanners.