### PR TITLE
Don't attempt to redact ImageJ, NDPI files

### DIFF
--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -13,6 +13,7 @@ from imagedephi.rules import Ruleset
 
 from .build_redaction_plan import FILE_EXTENSION_MAP, build_redaction_plan
 from .svs import MalformedAperioFileError
+from .tiff import UnsupportedFileTypeError
 
 
 def _get_output_path(file_path: Path, output_dir: Path) -> Path:
@@ -60,6 +61,9 @@ def redact_images(
                 f"{image_file.name} could not be processed as a valid Aperio file. Skipping..."
             )
             continue
+        except UnsupportedFileTypeError as e:
+            click.echo(f"{image_file.name} could not be processed. {e.args[0]}")
+            continue
         click.echo(f"Redacting {image_file.name}...")
         if not redaction_plan.is_comprehensive():
             click.echo(f"Redaction could not be performed for {image_file.name}.")
@@ -86,6 +90,9 @@ def show_redaction_plan(input_path: Path, override_rules: Ruleset | None = None)
             click.echo(
                 f"{image_path.name} could not be processed as a valid Aperio file.", err=True
             )
+            continue
+        except UnsupportedFileTypeError as e:
+            click.echo(f"{image_path.name} could not be processed. {e.args[0]}")
             continue
         print(f"\nRedaction plan for {image_path.name}")
         metadata_redaction_plan.report_plan()

--- a/imagedephi/redact/tiff.py
+++ b/imagedephi/redact/tiff.py
@@ -16,6 +16,10 @@ if TYPE_CHECKING:
     from tifftools.tifftools import IFD, TiffInfo
 
 
+class UnsupportedFileTypeError(Exception):
+    """Thrown when a file can be opened by tifftools but not redacted."""
+
+
 class TiffRedactionPlan(RedactionPlan):
     """
     Represents a plan of action for redacting metadata from TIFF images.
@@ -65,6 +69,10 @@ class TiffRedactionPlan(RedactionPlan):
         ifds = self.tiff_info["ifds"]
 
         for tag, _ in self._iter_tiff_tag_entries(ifds):
+            if tag.value == tifftools.constants.Tag["ImageJMetadata"].value:
+                raise UnsupportedFileTypeError("Redaction for ImageJ files is not supported")
+            if tag.value == tifftools.constants.Tag["NDPI_FORMAT_FLAG"].value:
+                raise UnsupportedFileTypeError("Redaction for NDPI files is not supported")
             tag_rule = None
             for name in [tag.name] + list(tag.get("altnames", set())):
                 tag_rule = rules.metadata.get(name, None)


### PR DESCRIPTION
Fixes #117 

These images can technically be opened by `tifftools`, but can't be written back out as those formats post redaction. Therefore, we should skip redaction on these kinds of images, instead of trying to redact and reporting as a failed redaction.