### PR TITLE
Add rule type for datatype checking

### DIFF
--- a/imagedephi/redact/svs.py
+++ b/imagedephi/redact/svs.py
@@ -171,10 +171,12 @@ class SvsRedactionPlan(TiffRedactionPlan):
                 image_description = SvsDescription(str(ifd["tags"][tag.value]["data"]))
                 for key_name, _data in image_description.metadata.items():
                     rule = self.description_redaction_steps[key_name]
-                    print(f"SVS Image Description - {key_name}: {rule.action}")
+                    operation = self.determine_redaction_operation(rule, image_description)
+                    print(f"SVS Image Description - {key_name}: {operation}")
                 continue
             rule = self.metadata_redaction_steps[tag.value]
-            print(f"Tiff Tag {tag.value} - {rule.key_name}: {rule.action}")
+            operation = self.determine_redaction_operation(rule, ifd)
+            print(f"Tiff Tag {tag.value} - {rule.key_name}: {operation}")
         self.report_missing_rules()
         print("Aperio (.svs) Associated Image Redaction Plan\n")
         match_counts = {}

--- a/imagedephi/redact/svs.py
+++ b/imagedephi/redact/svs.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 import tifftools
 import tifftools.constants
-from tifftools.tifftools import IFD
 
 from imagedephi.rules import ConcreteMetadataRule, FileFormat, RedactionOperation, SvsRules
 
@@ -109,12 +108,15 @@ class SvsRedactionPlan(TiffRedactionPlan):
             return rule.key_name == data
         return False
 
-    def determine_redaction_action(self, rule: ConcreteMetadataRule, data: SvsDescription | IFD) -> RedactionOperation:
+    def determine_redaction_action(
+        self, rule: ConcreteMetadataRule, data: SvsDescription | IFD
+    ) -> RedactionOperation:
         if isinstance(data, SvsDescription):
             if rule.action == "check_type":
-                valid_types = tuple(rule.valid_data_type)
                 value = data.metadata[rule.key_name]
-                passes_check = self.passes_type_check(value, valid_types, rule.expected_count)
+                passes_check = self.passes_type_check(
+                    value, rule.valid_data_types, rule.expected_count
+                )
                 return "keep" if passes_check else "delete"
             if rule.action in ["keep", "replace", "delete"]:
                 return rule.action

--- a/imagedephi/redact/svs.py
+++ b/imagedephi/redact/svs.py
@@ -182,9 +182,9 @@ class SvsRedactionPlan(TiffRedactionPlan):
         new_ifds = self._redact_associated_images(ifds)
         image_description_tag = tifftools.constants.Tag["ImageDescription"]
         for tag, ifd in self._iter_tiff_tag_entries(new_ifds):
-            rule = self.metadata_redaction_steps.get(tag.value)
-            if rule is not None:
-                self.apply(rule, ifd)
+            redaction_step = self.metadata_redaction_steps.get(tag.value)
+            if redaction_step is not None:
+                self.apply(redaction_step.rule, ifd)
             elif tag.value == image_description_tag.value:
                 self._redact_svs_image_description(ifd)
         self.tiff_info["ifds"] = new_ifds

--- a/imagedephi/redact/svs.py
+++ b/imagedephi/redact/svs.py
@@ -22,7 +22,18 @@ if TYPE_CHECKING:
 
 class SvsDescription:
     prefix: str
-    metadata: dict[str, str]
+    metadata: dict[str, str | int | float]
+
+    def try_get_numeric_value(self, value: str) -> str | int | float:
+        try:
+            int(value)
+            return int(value)
+        except ValueError:
+            try:
+                float(value)
+                return float(value)
+            except ValueError:
+                return value
 
     def __init__(self, svs_description_string: str):
         description_components = svs_description_string.split("|")
@@ -31,12 +42,12 @@ class SvsDescription:
         self.metadata = {}
         for metadata_component in description_components[1:]:
             key, value = [token.strip() for token in metadata_component.split("=")]
-            self.metadata[key] = value
+            self.metadata[key] = self.try_get_numeric_value(value)
 
     def __str__(self) -> str:
         components = [self.prefix]
         components = components + [
-            " = ".join([key, self.metadata[key]]) for key in self.metadata.keys()
+            " = ".join([key, str(self.metadata[key])]) for key in self.metadata.keys()
         ]
         return "|".join(components)
 

--- a/imagedephi/redact/svs.py
+++ b/imagedephi/redact/svs.py
@@ -102,7 +102,7 @@ class SvsRedactionPlan(TiffRedactionPlan):
         return "default"
 
     def is_match(self, rule: ConcreteMetadataRule, data: tifftools.TiffTag | str) -> bool:
-        if rule.action in ["keep", "delete", "replace"]:
+        if rule.action in ["keep", "delete", "replace", "check_type"]:
             if isinstance(data, tifftools.TiffTag):
                 return super().is_match(rule, data)
             return rule.key_name == data

--- a/imagedephi/redact/svs.py
+++ b/imagedephi/redact/svs.py
@@ -182,9 +182,9 @@ class SvsRedactionPlan(TiffRedactionPlan):
         new_ifds = self._redact_associated_images(ifds)
         image_description_tag = tifftools.constants.Tag["ImageDescription"]
         for tag, ifd in self._iter_tiff_tag_entries(new_ifds):
-            redaction_step = self.metadata_redaction_steps.get(tag.value)
-            if redaction_step is not None:
-                self.apply(redaction_step.rule, ifd)
+            rule = self.metadata_redaction_steps.get(tag.value)
+            if rule is not None:
+                self.apply(rule, ifd)
             elif tag.value == image_description_tag.value:
                 self._redact_svs_image_description(ifd)
         self.tiff_info["ifds"] = new_ifds

--- a/imagedephi/redact/svs.py
+++ b/imagedephi/redact/svs.py
@@ -25,6 +25,7 @@ class SvsDescription:
     metadata: dict[str, str | int | float]
 
     def try_get_numeric_value(self, value: str) -> str | int | float:
+        """Given an ImageDescription value, return a number version of it if applicable."""
         try:
             int(value)
             return int(value)

--- a/imagedephi/redact/tiff.py
+++ b/imagedephi/redact/tiff.py
@@ -113,7 +113,7 @@ class TiffRedactionPlan(RedactionPlan):
         self.no_match_tags = []
         ifds = self.tiff_info["ifds"]
 
-        for tag, _ifd in self._iter_tiff_tag_entries(ifds):
+        for tag, _ in self._iter_tiff_tag_entries(ifds):
             if tag.value == tifftools.constants.Tag["ImageJMetadata"].value:
                 raise UnsupportedFileTypeError("Redaction for ImageJ files is not supported")
             if tag.value == tifftools.constants.Tag["NDPI_FORMAT_FLAG"].value:
@@ -144,6 +144,15 @@ class TiffRedactionPlan(RedactionPlan):
     def passes_type_check(
         self, metadata_value: Any, valid_types: list[type], expected_count: int
     ) -> bool:
+        """
+        Determine if a metadata value passes is of the expected type.
+
+        Given a metadata value, a list of expected types, and a number of expected values,
+        return True if the metadata value either
+            a) is of the expected type or types or
+            b) is a list whose length is equal to the expected count, and each element of
+               said list is of the expected type or types.
+        """
         if isinstance(metadata_value, list):
             return len(metadata_value) == expected_count and all(
                 isinstance(item, tuple(valid_types)) for item in metadata_value

--- a/imagedephi/redact/tiff.py
+++ b/imagedephi/redact/tiff.py
@@ -136,7 +136,7 @@ class TiffRedactionPlan(RedactionPlan):
                 ]
 
     def is_match(self, rule: ConcreteMetadataRule, tag: tifftools.TiffTag) -> bool:
-        if rule.action in ["keep", "delete", "replace"]:
+        if rule.action in ["keep", "delete", "replace", "check_type"]:
             rule_tag = get_tiff_tag(rule.key_name)
             return rule_tag.value == tag.value
         return False
@@ -156,11 +156,12 @@ class TiffRedactionPlan(RedactionPlan):
 
     def _apply_check_type_metadata_rule(self, ifd: IFD, rule: CheckTypeMetadataRule, tag: tifftools.TiffTag):
         value = ifd["tags"][tag.value]["data"]
+        valid_types = tuple(rule.expected_type)
         passes_check = False
         if isinstance(value, list):
-            passes_check = len(value) == rule.expected_count and all(isinstance(item, rule.expected_type) for item in value)
+            passes_check = len(value) == rule.expected_count and all(isinstance(item, valid_types) for item in value)
         else:
-            passes_check = isinstance(value, rule.expected_type)
+            passes_check = isinstance(value, valid_types)
         if not passes_check:
             self._apply_delete_metadata_rule(ifd, tag)
 

--- a/imagedephi/redact/tiff.py
+++ b/imagedephi/redact/tiff.py
@@ -151,7 +151,7 @@ class TiffRedactionPlan(RedactionPlan):
         else:
             return isinstance(metadata_value, tuple(valid_types))
 
-    def determine_redaction_action(
+    def determine_redaction_operation(
         self, rule: ConcreteMetadataRule, ifd: IFD
     ) -> RedactionOperation:
         """
@@ -175,7 +175,7 @@ class TiffRedactionPlan(RedactionPlan):
 
     def apply(self, rule: ConcreteMetadataRule, ifd: IFD) -> None:
         tag = get_tiff_tag(rule.key_name)
-        operation = self.determine_redaction_action(rule, ifd)
+        operation = self.determine_redaction_operation(rule, ifd)
         if operation == "delete":
             del ifd["tags"][tag.value]
         elif operation == "replace":

--- a/imagedephi/redact/tiff.py
+++ b/imagedephi/redact/tiff.py
@@ -141,15 +141,15 @@ class TiffRedactionPlan(RedactionPlan):
             return rule_tag.value == tag.value
         return False
 
-    def passes_type_check(self, metadata_value: Any, valid_types: tuple[type], expected_count: int) -> bool:
-        passes_check = False
+    def passes_type_check(
+        self, metadata_value: Any, valid_types: list[type], expected_count: int
+    ) -> bool:
         if isinstance(metadata_value, list):
             return len(metadata_value) == expected_count and all(
-                isinstance(item, valid_types) for item in metadata_value
+                isinstance(item, tuple(valid_types)) for item in metadata_value
             )
         else:
-            return isinstance(metadata_value, valid_types)
-
+            return isinstance(metadata_value, tuple(valid_types))
 
     def determine_redaction_action(
         self, rule: ConcreteMetadataRule, ifd: IFD
@@ -164,9 +164,10 @@ class TiffRedactionPlan(RedactionPlan):
         if rule.action == "check_type":
             tag = get_tiff_tag(rule.key_name)
             value = ifd["tags"][tag.value]["data"]
-            valid_types = tuple(rule.valid_data_type)
-            expected_count = 2 * rule.expected_count if rule.expected_type == "rational" else rule.expected_count
-            passes_check = self.passes_type_check(value, valid_types, expected_count)
+            expected_count = (
+                2 * rule.expected_count if rule.expected_type == "rational" else rule.expected_count
+            )
+            passes_check = self.passes_type_check(value, rule.valid_data_types, expected_count)
             return "keep" if passes_check else "delete"
         if rule.action in ["keep", "replace", "delete"]:
             return rule.action

--- a/imagedephi/redact/tiff.py
+++ b/imagedephi/redact/tiff.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Generator
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from PIL import Image, TiffTags
 from PIL.TiffImagePlugin import ImageFileDirectory_v2
@@ -16,6 +16,7 @@ from imagedephi.rules import (
     FileFormat,
     ImageReplaceRule,
     MetadataRedactionStep,
+    RedactionOperation,
     TiffRules,
 )
 from imagedephi.utils.tiff import get_tiff_tag
@@ -123,7 +124,7 @@ class TiffRedactionPlan(RedactionPlan):
                 if tag_rule and self.is_match(tag_rule, tag):
                     self.metadata_redaction_steps[tag.value] = MetadataRedactionStep(
                         rule=tag_rule,
-                        action=self.determine_redaction_action(tag_rule, ifd),
+                        operation=self.determine_redaction_action(tag_rule, ifd),
                     )
                     break
             else:
@@ -145,7 +146,7 @@ class TiffRedactionPlan(RedactionPlan):
 
     def determine_redaction_action(
         self, rule: ConcreteMetadataRule, ifd: IFD
-    ) -> Literal["keep", "replace", "delete"]:
+    ) -> RedactionOperation:
         """
         Given a rule and the IFD it applies to, return the actual action.
 

--- a/imagedephi/redact/tiff.py
+++ b/imagedephi/redact/tiff.py
@@ -11,12 +11,10 @@ import tifftools
 import tifftools.constants
 
 from imagedephi.rules import (
-    CheckTypeMetadataRule,
     ConcreteImageRule,
     ConcreteMetadataRule,
     FileFormat,
     ImageReplaceRule,
-    MetadataReplaceRule,
     TiffRules,
 )
 from imagedephi.utils.tiff import get_tiff_tag

--- a/imagedephi/redact/tiff.py
+++ b/imagedephi/redact/tiff.py
@@ -203,7 +203,8 @@ class TiffRedactionPlan(RedactionPlan):
                 ifd_count += 1
                 print(f"IFD {ifd_count}:")
             rule = self.metadata_redaction_steps[tag.value]
-            print(f"Tiff Tag {tag.value} - {rule.key_name}: {rule.action}")
+            operation = self.determine_redaction_operation(rule, ifd)
+            print(f"Tiff Tag {tag.value} - {rule.key_name}: {operation}")
         self.report_missing_rules()
         print("Tiff Associated Image Redaction Plan\n")
         print(f"Found {len(self.image_redaction_steps)} associated images")

--- a/imagedephi/rules.py
+++ b/imagedephi/rules.py
@@ -8,9 +8,9 @@ class FileFormat(Enum):
     TIFF = "tiff"
     SVS = "svs"
 
-expected_type_map: dict[str, tuple[Type[Any]]] = {
-    "number": tuple([int, float]),
-    "text": (str,)
+expected_type_map: dict[str, list[Type[Any]]] = {
+    "number": [int, float],
+    "text": [str]
 }
 
 
@@ -42,10 +42,10 @@ class ImageReplaceRule(ReplaceRule):
 
 class CheckTypeMetadataRule(_Rule):
     action: Literal["check_type"]
-    expected_type: tuple[Type[Any]]
+    expected_type: list[Type[Any]]
     expected_count: int
 
-    @validator("exptected_type", pre=True)
+    @validator("expected_type", pre=True)
     @classmethod
     def set_expected_type(cls, expected_type: Any):
         if (expected_type in expected_type_map):

--- a/imagedephi/rules.py
+++ b/imagedephi/rules.py
@@ -8,10 +8,8 @@ class FileFormat(Enum):
     TIFF = "tiff"
     SVS = "svs"
 
-expected_type_map: dict[str, list[Type[Any]]] = {
-    "number": [int, float],
-    "text": [str]
-}
+
+expected_type_map: dict[str, list[Type[Any]]] = {"number": [int, float], "text": [str]}
 
 
 class _Rule(BaseModel):
@@ -48,7 +46,7 @@ class CheckTypeMetadataRule(_Rule):
     @validator("expected_type", pre=True)
     @classmethod
     def set_expected_type(cls, expected_type: Any):
-        if (expected_type in expected_type_map):
+        if expected_type in expected_type_map:
             return expected_type_map[expected_type]
         raise Exception(f"Invalid value for expected_type: {expected_type}")
 

--- a/imagedephi/rules.py
+++ b/imagedephi/rules.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Annotated, Any, Literal, Type
+from typing import Annotated, Any, Literal, Type, TypeAlias
 
 from pydantic import BaseModel, Field, validator
 
@@ -14,6 +14,8 @@ expected_type_map: dict[str, list[Type[Any]]] = {
     "number": [int, float],
     "text": [str],
 }
+
+RedactionOperation: TypeAlias = Literal["keep", "delete", "replace"]
 
 
 class _Rule(BaseModel):
@@ -67,7 +69,7 @@ ConcreteImageRule = Annotated[
 
 class MetadataRedactionStep(BaseModel):
     rule: ConcreteMetadataRule
-    action: Literal["keep", "delete", "replace"]
+    operation: RedactionOperation
 
 
 class BaseRules(BaseModel):

--- a/imagedephi/rules.py
+++ b/imagedephi/rules.py
@@ -67,11 +67,6 @@ ConcreteImageRule = Annotated[
 ]
 
 
-class MetadataRedactionStep(BaseModel):
-    rule: ConcreteMetadataRule
-    operation: RedactionOperation
-
-
 class BaseRules(BaseModel):
     matches: list[str]
 

--- a/imagedephi/rules.py
+++ b/imagedephi/rules.py
@@ -13,6 +13,7 @@ expected_type_map: dict[str, list[Type[Any]]] = {
     "integer": [int],
     "number": [int, float],
     "text": [str],
+    "rational": [int]
 }
 
 RedactionOperation: TypeAlias = Literal["keep", "delete", "replace"]
@@ -46,15 +47,19 @@ class ImageReplaceRule(ReplaceRule):
 
 class CheckTypeMetadataRule(_Rule):
     action: Literal["check_type"]
-    expected_type: list[Type[Any]]
+    expected_type: Literal["number", "integer", "text", "rational"]
+    valid_data_type: list[Type[Any]] = []
     expected_count: int
 
-    @validator("expected_type", pre=True)
+    @validator("valid_data_type", pre=True, always=True)
     @classmethod
-    def set_expected_type(cls, expected_type: Any):
-        if expected_type in expected_type_map:
-            return expected_type_map[expected_type]
-        raise Exception(f"Invalid value for expected_type: {expected_type}")
+    def set_valid_data_type(
+        cls,
+        valid_data_type: list[Type[Any]],
+        values: dict[str, Any]
+    ) -> list[Type[Any]]:
+        valid_data_type = expected_type_map[values["expected_type"]]
+        return valid_data_type
 
 
 ConcreteMetadataRule = Annotated[

--- a/imagedephi/rules.py
+++ b/imagedephi/rules.py
@@ -9,7 +9,11 @@ class FileFormat(Enum):
     SVS = "svs"
 
 
-expected_type_map: dict[str, list[Type[Any]]] = {"number": [int, float], "text": [str]}
+expected_type_map: dict[str, list[Type[Any]]] = {
+    "integer": [int],
+    "number": [int, float],
+    "text": [str],
+}
 
 
 class _Rule(BaseModel):

--- a/imagedephi/rules.py
+++ b/imagedephi/rules.py
@@ -65,6 +65,11 @@ ConcreteImageRule = Annotated[
 ]
 
 
+class MetadataRedactionStep(BaseModel):
+    rule: ConcreteMetadataRule
+    action: Literal["keep", "delete", "replace"]
+
+
 class BaseRules(BaseModel):
     matches: list[str]
 

--- a/imagedephi/rules.py
+++ b/imagedephi/rules.py
@@ -13,7 +13,7 @@ expected_type_map: dict[str, list[Type[Any]]] = {
     "integer": [int],
     "number": [int, float],
     "text": [str],
-    "rational": [int]
+    "rational": [int],
 }
 
 RedactionOperation: TypeAlias = Literal["keep", "delete", "replace"]
@@ -48,18 +48,16 @@ class ImageReplaceRule(ReplaceRule):
 class CheckTypeMetadataRule(_Rule):
     action: Literal["check_type"]
     expected_type: Literal["number", "integer", "text", "rational"]
-    valid_data_type: list[Type[Any]] = []
+    valid_data_types: list[Type[Any]] = []
     expected_count: int
 
-    @validator("valid_data_type", pre=True, always=True)
+    @validator("valid_data_types", pre=True, always=True)
     @classmethod
-    def set_valid_data_type(
-        cls,
-        valid_data_type: list[Type[Any]],
-        values: dict[str, Any]
+    def set_valid_data_types(
+        cls, valid_data_types: list[Type[Any]], values: dict[str, Any]
     ) -> list[Type[Any]]:
-        valid_data_type = expected_type_map[values["expected_type"]]
-        return valid_data_type
+        valid_data_types = expected_type_map[values["expected_type"]]
+        return valid_data_types
 
 
 ConcreteMetadataRule = Annotated[

--- a/imagedephi/rules.py
+++ b/imagedephi/rules.py
@@ -49,7 +49,7 @@ class CheckTypeMetadataRule(_Rule):
     action: Literal["check_type"]
     expected_type: Literal["number", "integer", "text", "rational"]
     valid_data_types: list[Type[Any]] = []
-    expected_count: int
+    expected_count: int = 1
 
     @validator("valid_data_types", pre=True, always=True)
     @classmethod

--- a/imagedephi/rules.py
+++ b/imagedephi/rules.py
@@ -56,7 +56,8 @@ class CheckTypeMetadataRule(_Rule):
 
 
 ConcreteMetadataRule = Annotated[
-    MetadataReplaceRule | KeepRule | DeleteRule | CheckTypeMetadataRule, Field(discriminator="action")
+    MetadataReplaceRule | KeepRule | DeleteRule | CheckTypeMetadataRule,
+    Field(discriminator="action"),
 ]
 
 ConcreteImageRule = Annotated[

--- a/imagedephi/rules.py
+++ b/imagedephi/rules.py
@@ -8,11 +8,15 @@ class FileFormat(Enum):
     TIFF = "tiff"
     SVS = "svs"
 
+class DataType(Enum):
+    NUMBER = 0
+    TEXT = 1
+
 
 class _Rule(BaseModel):
     # key_name is not set by users, but is availible internally
     key_name: str = Field(exclude=True)
-    action: Literal["keep", "delete", "replace"]
+    action: Literal["keep", "delete", "replace", "check_type"]
 
 
 class KeepRule(_Rule):
@@ -33,6 +37,12 @@ class MetadataReplaceRule(ReplaceRule):
 
 class ImageReplaceRule(ReplaceRule):
     replace_with: Literal["blank_image"]
+
+
+class CheckTypeMetadataRule(_MetadataRule):
+    action: Literal["check_type"]
+    expected_type: DataType
+    expected_count: int
 
 
 ConcreteMetadataRule = Annotated[

--- a/tests/override_rule_sets/example_user_rules.yml
+++ b/tests/override_rule_sets/example_user_rules.yml
@@ -8,10 +8,17 @@ tiff:
     ImageDescription:
       action: replace
       new_value: Redacted by ImageDePHI
+    YCbCrSubsampling:
+      action: check_type
+      expected_type: number
+      expected_count: 2
 
 svs:
-  associated_images: {}
-  metadata: {}
+  metadata:
+    YCbCrSubsampling:
+      action: check_type
+      expected_type: number
+      expected_count: 2
   image_description:
     ICC Profile:
       action: delete

--- a/tests/override_rule_sets/example_user_rules.yml
+++ b/tests/override_rule_sets/example_user_rules.yml
@@ -23,3 +23,6 @@ svs:
   image_description:
     ICC Profile:
       action: delete
+    Filename:
+      action: check_type
+      expected_type: number

--- a/tests/override_rule_sets/example_user_rules.yml
+++ b/tests/override_rule_sets/example_user_rules.yml
@@ -14,6 +14,7 @@ tiff:
       expected_count: 2
 
 svs:
+  associated_images: {}
   metadata:
     YCbCrSubsampling:
       action: check_type

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -49,3 +49,4 @@ def test_plan_svs(capsys, svs_input_path, override_rule_set):
     captured = capsys.readouterr()
     assert "Aperio (.svs) Metadata Redaction Plan" in captured.out
     assert "ICC Profile: delete" in captured.out
+    assert "Filename: keep" in captured.out


### PR DESCRIPTION
This PR introduces a first pass at a new metadata rule type: `check_type`. 

Redaction for these kinds of rules will check the datatype of metadata on the image and either:
1. Remove the metadata if the datatype of existing data doesn't match what the rule states the datatype should be
2. Keep the metadata if it is of the expected type

As a first pass, these rules are tailored for tiff metadata. They have an `expected_type` and `expected_count` property, which are analogs to `tifftools.Tag`'s `datatype` and `count`. 