### PR TITLE
Use better name for redacted images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Redacted Images
 */REDACTED_*
+*/Redacted_*/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/imagedephi/base_rules.yaml
+++ b/imagedephi/base_rules.yaml
@@ -2,6 +2,7 @@ name: Base rules
 description: These are the default rules for each potential piece of redactable material
   (metadata, image) to be used as a fallback if there are no user defined rules for
   a piece of redactable material.
+output_file_name: study_slide
 tiff:
   associated_images:
     default:

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -24,9 +24,7 @@ def _get_output_path(
     count: int,
     max: int,
 ) -> Path:
-    number_length = len(str(max))
-    number = str(count).zfill(number_length)
-    return output_dir / f"{base_name}_{number}{file_path.suffix}"
+    return output_dir / f"{base_name}_{count:0{len(str(max))}}{file_path.suffix}"
 
 
 def get_base_rules():

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 import datetime
 import importlib.resources
 from pathlib import Path
+from uuid import uuid4
 
 import click
 import tifftools
@@ -18,7 +19,8 @@ from .tiff import UnsupportedFileTypeError
 
 
 def _get_output_path(file_path: Path, output_dir: Path) -> Path:
-    return output_dir / f"REDACTED_{file_path.name}"
+    output_path = output_dir / f"{uuid4()}{file_path.suffix}"
+    return output_path
 
 
 def get_base_rules():

--- a/imagedephi/rules.py
+++ b/imagedephi/rules.py
@@ -80,5 +80,6 @@ class SvsRules(TiffRules):
 class Ruleset(BaseModel):
     name: str
     description: str
+    output_file_name: str
     tiff: TiffRules
     svs: SvsRules

--- a/tests/override_rule_sets/example_user_rules.yml
+++ b/tests/override_rule_sets/example_user_rules.yml
@@ -1,6 +1,7 @@
 ---
 name: Example user rules
 description: A set of reasonable rules used for testing
+output_file_name: my_study_slide
 tiff:
   associated_images: {}
   metadata:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -37,8 +37,7 @@ def test_e2e_run(cli_runner: CliRunner, data_dir: Path, rules_dir: Path, tmp_pat
     )
 
     assert result.exit_code == 0
-    output_dir = tmp_path / "Redacted_2023-05-12_12-12-53"
-    output_file = [path for path in output_dir.iterdir()][0]
+    output_file = tmp_path / "Redacted_2023-05-12_12-12-53" / "my_study_slide_1.tif"
     output_file_bytes = output_file.read_bytes()
     assert b"large_image_converter" not in output_file_bytes
     assert b"Redacted by ImageDePHI" in output_file_bytes
@@ -102,8 +101,7 @@ def test_e2e_gui(
 
     assert cli_result.exit_code == 0
     webbrowser_open_mock.assert_called_once()
-    output_dir = tmp_path / "Redacted_2023-05-12_12-12-53"
-    output_file = [path for path in output_dir.iterdir()][0]
+    output_file = tmp_path / "Redacted_2023-05-12_12-12-53" / "study_slide_1.tif"
     output_file_bytes = output_file.read_bytes()
     assert b"large_image_converter" not in output_file_bytes
     assert f"127.0.0.1:{unused_tcp_port}" in webbrowser_open_mock.call_args.args[0]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -37,7 +37,8 @@ def test_e2e_run(cli_runner: CliRunner, data_dir: Path, rules_dir: Path, tmp_pat
     )
 
     assert result.exit_code == 0
-    output_file = tmp_path / "Redacted_2023-05-12_12-12-53" / "REDACTED_test_image.tif"
+    output_dir = tmp_path / "Redacted_2023-05-12_12-12-53"
+    output_file = [path for path in output_dir.iterdir()][0]
     output_file_bytes = output_file.read_bytes()
     assert b"large_image_converter" not in output_file_bytes
     assert b"Redacted by ImageDePHI" in output_file_bytes
@@ -101,7 +102,8 @@ def test_e2e_gui(
 
     assert cli_result.exit_code == 0
     webbrowser_open_mock.assert_called_once()
-    output_file = tmp_path / "Redacted_2023-05-12_12-12-53" / "REDACTED_test_image.tif"
+    output_dir = tmp_path / "Redacted_2023-05-12_12-12-53"
+    output_file = [path for path in output_dir.iterdir()][0]
     output_file_bytes = output_file.read_bytes()
     assert b"large_image_converter" not in output_file_bytes
     assert f"127.0.0.1:{unused_tcp_port}" in webbrowser_open_mock.call_args.args[0]

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -35,7 +35,8 @@ def test_create_redact_dir(tmp_path):
 def test_redact_svs(svs_input_path, tmp_path, override_rule_set):
     redact.redact_images(svs_input_path, tmp_path, override_rule_set)
 
-    output_file = tmp_path / "Redacted_2023-05-12_12-12-53" / "REDACTED_test_svs_image_blank.svs"
+    output_dir = tmp_path / "Redacted_2023-05-12_12-12-53"
+    output_file = [path for path in output_dir.iterdir()][0]
     svs_output_file_bytes = output_file.read_bytes()
     # verify our custom svs rule was applied
     assert b"ICC Profile" not in svs_output_file_bytes

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -35,8 +35,7 @@ def test_create_redact_dir(tmp_path):
 def test_redact_svs(svs_input_path, tmp_path, override_rule_set):
     redact.redact_images(svs_input_path, tmp_path, override_rule_set)
 
-    output_dir = tmp_path / "Redacted_2023-05-12_12-12-53"
-    output_file = [path for path in output_dir.iterdir()][0]
+    output_file = tmp_path / "Redacted_2023-05-12_12-12-53" / "my_study_slide_1.svs"
     svs_output_file_bytes = output_file.read_bytes()
     # verify our custom svs rule was applied
     assert b"ICC Profile" not in svs_output_file_bytes


### PR DESCRIPTION
This PR updates how we name redacted files. Instead of prepending `REDACTED_` to the input file names, prefix defined in the rules and a number, which increments with each slide redacted so far in the current run of Image DePHI.

It introduces a new property for `RuleSet`s: `output_file_name`. If `output_file_name` is `redacted_image`, then redacted images will follow the naming pattern `redacted_image_1.svs`, `redacted_image_2.svs`, etc.

This makes it harder to map back to the original file without comparing the images in the output and input directories. Future improvements could be including the SHA of the original image in the redacted image metadata.

Fix #60 