### PR TITLE
Revamp redaction report

### DIFF
--- a/imagedephi/redact/tiff.py
+++ b/imagedephi/redact/tiff.py
@@ -161,8 +161,15 @@ class TiffRedactionPlan(RedactionPlan):
 
     def report_plan(self) -> None:
         print("Tiff Metadata Redaction Plan\n")
-        for tag_value, rule in self.metadata_redaction_steps.items():
-            print(f"Tiff Tag {tag_value} - {rule.key_name}: {rule.action}")
+        offset = -1
+        ifd_count = 0
+        for tag, ifd in self._iter_tiff_tag_entries(self.tiff_info["ifds"]):
+            if ifd["offset"] != offset:
+                offset = ifd["offset"]
+                ifd_count += 1
+                print(f"IFD {ifd_count}:")
+            rule = self.metadata_redaction_steps[tag.value]
+            print(f"Tiff Tag {tag.value} - {rule.key_name}: {rule.action}")
         self.report_missing_rules()
         print("Tiff Associated Image Redaction Plan\n")
         print(f"Found {len(self.image_redaction_steps)} associated images")


### PR DESCRIPTION
This PR changed how redaction plans are reported. Now, we display all of the redaction steps per IFD, instead of per tag/key.

This means that if multiple IFDs in an image have an `ImageDescription`, the report will break down what the redaction will look like for all instances of `ImageDescription`.

This is important because now we loop through the IFDs and tags of images when displaying the report. Because of this change, we have access to the metadata while printing the plan. In the future, this will make it easier to actually include the changes that will be made in the report, or display them in the UI.

It will also help future development for rules that sometimes delete metadata and sometimes keep metadata (e.g. type-checking rules).