### PR TITLE
Fix bug in iter_ifds returning IFDs several times

### DIFF
--- a/imagedephi/redact/tiff.py
+++ b/imagedephi/redact/tiff.py
@@ -61,9 +61,7 @@ class TiffRedactionPlan(RedactionPlan):
                     tagSet=tag_set,
                     datatype=tifftools.Datatype[entry["datatype"]],
                 )
-                if not tag.isIFD():
-                    yield ifd
-                else:
+                if tag.isIFD():
                     # entry['ifds'] contains a list of lists
                     # see tifftools.read_tiff
                     for sub_ifds in entry.get("ifds", []):


### PR DESCRIPTION
Fix #133 

Fixes a bug in `_iter_ifds` that would cause an IFD to be `yield`ed once for each non-IFD tag contained within.