### PR TITLE
Determine associated image type without ImageDescription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.envrc
+.vscode/*
 # Redacted Images
 */REDACTED_*
 */Redacted_*/

--- a/imagedephi/redact/svs.py
+++ b/imagedephi/redact/svs.py
@@ -111,12 +111,21 @@ class SvsRedactionPlan(TiffRedactionPlan):
 
         This will return `"default`" if no semantics can be determined.
         """
+        # Check image description, it may contain 'macro' or 'label'
         image_description_tag = tifftools.constants.Tag["ImageDescription"]
         image_description = str(ifd["tags"].get(image_description_tag.value, {}).get("data", ''))
-        # we could do additional checks, like look for a macro based on dimensions
         for key in self.rules.associated_images:
             if key in image_description:
                 return key
+
+        # Check NewSubFileType bitmask. 'macro' could be encoded here
+        newsubfiletype_tag = tifftools.constants.Tag["NewSubfileType"]
+        newsubfiletype = ifd["tags"].get(newsubfiletype_tag.value, {}).get("data", [None])[0]
+        if newsubfiletype:
+            reduced_image_bit = tifftools.constants.NewSubfileType["ReducedImage"].value
+            macro_bit = tifftools.constants.NewSubfileType["Macro"].value
+            if newsubfiletype & reduced_image_bit and newsubfiletype & macro_bit:
+                return "macro"
         return "default"
 
     def is_match(self, rule: ConcreteMetadataRule, data: tifftools.TiffTag | str) -> bool:

--- a/imagedephi/redact/svs.py
+++ b/imagedephi/redact/svs.py
@@ -112,7 +112,7 @@ class SvsRedactionPlan(TiffRedactionPlan):
         This will return `"default`" if no semantics can be determined.
         """
         image_description_tag = tifftools.constants.Tag["ImageDescription"]
-        image_description = str(ifd["tags"][image_description_tag.value]["data"])
+        image_description = str(ifd["tags"].get(image_description_tag.value, {}).get("data", ''))
         # we could do additional checks, like look for a macro based on dimensions
         for key in self.rules.associated_images:
             if key in image_description:

--- a/imagedephi/redact/svs.py
+++ b/imagedephi/redact/svs.py
@@ -113,15 +113,16 @@ class SvsRedactionPlan(TiffRedactionPlan):
         """
         # Check image description, it may contain 'macro' or 'label'
         image_description_tag = tifftools.constants.Tag["ImageDescription"]
-        image_description = str(ifd["tags"].get(image_description_tag.value, {}).get("data", ''))
-        for key in self.rules.associated_images:
-            if key in image_description:
-                return key
+        if image_description_tag.value in ifd["tags"]:
+            image_description = str(ifd["tags"][image_description_tag.value]["data"])
+            for key in self.rules.associated_images:
+                if key in image_description:
+                    return key
 
         # Check NewSubFileType bitmask. 'macro' could be encoded here
         newsubfiletype_tag = tifftools.constants.Tag["NewSubfileType"]
-        newsubfiletype = ifd["tags"].get(newsubfiletype_tag.value, {}).get("data", [None])[0]
-        if newsubfiletype:
+        if newsubfiletype_tag.value in ifd["tags"]:
+            newsubfiletype = ifd["tags"][newsubfiletype_tag.value]["data"][0]
             reduced_image_bit = tifftools.constants.NewSubfileType["ReducedImage"].value
             macro_bit = tifftools.constants.NewSubfileType["Macro"].value
             if newsubfiletype & reduced_image_bit and newsubfiletype & macro_bit:

--- a/stubs/tifftools/constants.pyi
+++ b/stubs/tifftools/constants.pyi
@@ -37,6 +37,8 @@ GPSTag: TiffConstantSet[TiffTag]
 
 EXIFTag: TiffConstantSet[TiffTag]
 
+NewSubfileType: TiffConstantSet
+
 class TiffDatatype(TiffConstant): ...
 
 Datatype: TiffConstantSet[TiffDatatype]

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -1,3 +1,4 @@
+import importlib.resources
 from pathlib import Path, PurePath
 
 from freezegun import freeze_time
@@ -6,7 +7,15 @@ import yaml
 
 from imagedephi import redact
 from imagedephi.redact.redact import create_redact_dir
+from imagedephi.redact.svs import SvsRedactionPlan
 from imagedephi.rules import Ruleset
+
+
+@pytest.fixture
+def base_rule_set():
+    base_rules_path = importlib.resources.files("imagedephi") / "base_rules.yaml"
+    with base_rules_path.open() as base_rules_stream:
+        return Ruleset.parse_obj(yaml.safe_load(base_rules_stream))
 
 
 @pytest.fixture
@@ -50,3 +59,29 @@ def test_plan_svs(capsys, svs_input_path, override_rule_set):
     assert "Aperio (.svs) Metadata Redaction Plan" in captured.out
     assert "ICC Profile: delete" in captured.out
     assert "Filename: keep" in captured.out
+
+
+def test_associated_image_key_no_description(data_dir, base_rule_set):
+    input_image = data_dir / "input" / "svs" / "test_svs_image_blank.svs"
+    svs_redaction_plan = SvsRedactionPlan(input_image, base_rule_set.svs)
+    test_tags = {
+        254: {
+            "datatype": 4,
+            "count": 1,
+            "datapos": 0,
+            "data": [9],
+        }
+    }
+    test_ifd = {
+        "offset": 0,
+        "tags": test_tags,
+        "path_or_fobj": "",
+        "size": 0,
+        "bigEndian": False,
+        "bigtiff": False,
+        "tagcount": 1,
+    }
+    associated_image_key = svs_redaction_plan.get_associated_image_key_for_ifd(
+        test_ifd,  # type: ignore
+    )
+    assert associated_image_key == "macro"


### PR DESCRIPTION
Fix #142 

Some SVS files have IFDs that represent an associated image but do NOT have the `ImageDescription` tag.

Previously, redaction for svs images assumed the existence of `ImageDescription` for every IFD in the image.

Now, if the `ImageDescription` is not found, or if the type of associated image could not be determined from the `ImageDescription` tag, we fall back to tag 254, `NewSubfileType`. This is a bitmask, and we can determine if an IFD represents a macro image from this bitmask.

A test has also been added, but this test uses a hard-coded IFD-like dictionary instead of a new image. It didn't feel worth it to add a new image to LFS to test this particular case, but I'm open to revisiting this decision if the added test is not sufficient.