### PR TITLE
Extract thumbnail image data when PIL can't read an IFD

### DIFF
--- a/imagedephi/gui.py
+++ b/imagedephi/gui.py
@@ -132,7 +132,7 @@ def get_composite_image(ifd: IFD, file_name: str):
 
     height = int(ifd["tags"][tifftools.Tag.ImageLength.value]["data"][0])
     width = int(ifd["tags"][tifftools.Tag.ImageWidth.value]["data"][0])
-    samples = ifd["tags"][tifftools.Tag.SamplesPerPixel.value]["data"][0]
+    samples = int(ifd["tags"][tifftools.Tag.SamplesPerPixel.value]["data"][0])
     image_array = np.zeros((height, width, samples))
     x_start: int = 0
     y_start: int = 0

--- a/imagedephi/gui.py
+++ b/imagedephi/gui.py
@@ -131,7 +131,6 @@ def extract_thumbnail_from_image_bytes(ifd: IFD, file_name: str) -> Image.Image 
 
     height = int(ifd["tags"][tifftools.Tag.ImageLength.value]["data"][0])
     width = int(ifd["tags"][tifftools.Tag.ImageWidth.value]["data"][0])
-    samples = int(ifd["tags"][tifftools.Tag.SamplesPerPixel.value]["data"][0])
     top: int = 0
     left: int = 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "hypercorn",
     "pyyaml",
     "Pillow",
-    "numpy",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "hypercorn",
     "pyyaml",
     "Pillow",
+    "numpy",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Fix #151 

This PR adds a fallback method to obtain a thumbnail image from a tiff/svs file when PIL can't open a thumbnail IFD. This is necessary because PIL's tiff reader can't read tiff images that are JPEG2k encoded.

In this case, the low res image determined to be the thumbail is extracted from the original tiff/svs image data.

To see the endpoint in action, run `imagedephi gui` and point your browser towards: 
`localhost:<port>/image/?file_name=<path/to/file>&image_key=thumbnail`