### PR TITLE
Implement DICOM metadata redaction

### DIFF
--- a/imagedephi/base_rules.yaml
+++ b/imagedephi/base_rules.yaml
@@ -1369,11 +1369,3 @@ dicom:
       action: keep
     PixelMeasuresSequence:
       action: keep
-# A note about DICOM --
-# ---------------------
-# The documentation used to generate the initial set of rules includes redaction
-# rules for entire Sequences. This should be accounted for during plan creation.
-# What happens if a sequence is marked to be deleted and an element of that
-# sequence has a different action for it?
-# Should iteration over dicom data elements return both the sequence and all
-# subelements of the sequence?

--- a/imagedephi/base_rules.yaml
+++ b/imagedephi/base_rules.yaml
@@ -1307,3 +1307,73 @@ dicom:
       action: delete
     VisitComments:
       action: delete
+    InstanceNumber:
+      action: keep
+    DimensionOrganizationSequence:
+      action: keep
+    DimensionIndexSequence:
+      action: keep
+    DimensionOrganizationType:
+      action: keep
+    SamplesPerPixel:
+      action: keep
+    PhotometricInterpretation:
+      action: keep
+    PlanarConfiguration:
+      action: keep
+    NumberOfFrames:
+      action: keep
+    FrameIncrementPointer:
+      action: keep
+    Rows:
+      action: keep
+    Columns:
+      action: keep
+    BitsAllocated:
+      action: keep
+    BitsStored:
+      action: keep
+    HighBit:
+      action: keep
+    PixelRepresentation:
+      action: keep
+    LossyImageCompression:
+      action: keep
+    RepresentativeFrameNumber:
+      action: keep
+    ImagedVolumeWidth:
+      action: keep
+    ImagedVolumeHeight:
+      action: keep
+    TotalPixelMatrixColumns:
+      action: keep
+    TotalPixelMatrixRows:
+      action: keep
+    ImageOrientationSlide:
+      action: keep
+    SharedFunctionalGroupsSequence:
+      action: keep
+    PixelData:
+      action: keep
+    ImageType:
+      action: keep
+    SOPClassUID:
+      action: replace_uid
+    Modality:
+      action: keep
+    DimensionIndexPointer:
+      action: keep
+    FunctionalGroupPointer:
+      action: keep
+    PixelSpacing:
+      action: keep
+    PixelMeasuresSequence:
+      action: keep
+# A note about DICOM --
+# ---------------------
+# The documentation used to generate the initial set of rules includes redaction
+# rules for entire Sequences. This should be accounted for during plan creation.
+# What happens if a sequence is marked to be deleted and an element of that
+# sequence has a different action for it?
+# Should iteration over dicom data elements return both the sequence and all
+# subelements of the sequence?

--- a/imagedephi/redact/build_redaction_plan.py
+++ b/imagedephi/redact/build_redaction_plan.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from imagedephi.rules import FileFormat, Ruleset
 
+from .dicom import DicomRedactionPlan
 from .redaction_plan import RedactionPlan
 from .svs import SvsRedactionPlan
 from .tiff import TiffRedactionPlan
@@ -10,6 +11,7 @@ FILE_EXTENSION_MAP: dict[str, FileFormat] = {
     ".tif": FileFormat.TIFF,
     ".tiff": FileFormat.TIFF,
     ".svs": FileFormat.SVS,
+    ".dcm": FileFormat.DICOM,
 }
 
 
@@ -30,5 +32,10 @@ def build_redaction_plan(
             merged_rules.image_description.update(override_rules.svs.image_description)
 
         return SvsRedactionPlan(image_path, merged_rules)
+    elif file_extension == FileFormat.DICOM:
+        merged_rules = base_rules.dicom.copy()
+        if override_rules:
+            merged_rules.metadata.update(override_rules.dicom.metadata)
+        return DicomRedactionPlan(image_path, merged_rules)
     else:
         raise Exception(f"File format for {image_path} not supported.")

--- a/imagedephi/redact/build_redaction_plan.py
+++ b/imagedephi/redact/build_redaction_plan.py
@@ -33,9 +33,9 @@ def build_redaction_plan(
 
         return SvsRedactionPlan(image_path, merged_rules)
     elif file_extension == FileFormat.DICOM:
-        merged_rules = base_rules.dicom.copy()
+        dicom_rules = base_rules.dicom.copy()
         if override_rules:
-            merged_rules.metadata.update(override_rules.dicom.metadata)
-        return DicomRedactionPlan(image_path, merged_rules)
+            dicom_rules.metadata.update(override_rules.dicom.metadata)
+        return DicomRedactionPlan(image_path, dicom_rules)
     else:
         raise Exception(f"File format for {image_path} not supported.")

--- a/imagedephi/redact/dicom.py
+++ b/imagedephi/redact/dicom.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pydicom
+from pydicom import valuerep
+from pydicom.datadict import keyword_for_tag
+from pydicom.dataelem import DataElement
+from pydicom.dataset import Dataset
+from pydicom.tag import BaseTag
+
+from imagedephi.rules import (
+    ConcreteMetadataRule,
+    DicomRules,
+    FileFormat,
+    MetadataReplaceRule,
+    RedactionOperation,
+)
+from imagedephi.utils.logger import logger
+
+from .redaction_plan import RedactionPlan
+
+VR_TO_DUMMY_VALUE = {}
+for vr in valuerep.STR_VR:
+    VR_TO_DUMMY_VALUE[vr] = ""
+for vr in valuerep.FLOAT_VR:
+    VR_TO_DUMMY_VALUE[vr] = 0.0
+for vr in valuerep.INT_VR:
+    VR_TO_DUMMY_VALUE[vr] = 0
+for vr in valuerep.LIST_VR:
+    VR_TO_DUMMY_VALUE[vr] = []
+for vr in valuerep.BYTES_VR:
+    VR_TO_DUMMY_VALUE[vr] = b""
+
+VR_TO_EXPECTED_TYPE = {}
+for vr in valuerep.STR_VR:
+    VR_TO_EXPECTED_TYPE[vr] = str
+for vr in valuerep.FLOAT_VR:
+    VR_TO_EXPECTED_TYPE[vr] = float
+for vr in valuerep.INT_VR:
+    VR_TO_EXPECTED_TYPE[vr] = int
+for vr in valuerep.LIST_VR:
+    VR_TO_EXPECTED_TYPE[vr] = list
+for vr in valuerep.BYTES_VR:
+    VR_TO_DUMMY_VALUE[vr] = bytes
+
+
+class DicomRedactionPlan(RedactionPlan):
+    """
+    Represents a plan of action for redacting metadata from DICOM images.
+
+    Each instance of this class works on a single .dcm file.
+    """
+
+    file_format = FileFormat.DICOM
+    image_path: Path
+    dicom_data: pydicom.FileDataset
+    metadata_redaction_steps: dict[int, ConcreteMetadataRule]
+    no_match_tags: list[BaseTag]
+    uid_map: dict[str, str]
+
+    @staticmethod
+    def _iter_dicom_elements(
+        dicom_dataset: Dataset,
+    ) -> Generator[tuple[DataElement, Dataset], None, None]:
+        for element in dicom_dataset:
+            if element.VR == "SQ":
+                for dataset in element.value:
+                    yield from DicomRedactionPlan._iter_dicom_elements(dataset)
+                # Treat the sequence as its own element as well.
+                # Some of the rules generated from the DICOM docs
+                # include rules for sequences.
+                # Return the sequence after to protect against deletion while looping.
+                yield element, dicom_dataset
+            else:
+                yield element, dicom_dataset
+
+    def __init__(self, image_path: Path, rules: DicomRules) -> None:
+        self.image_path = image_path
+        self.dicom_data = pydicom.dcmread(image_path)
+
+        self.metadata_redaction_steps = {}
+        self.no_match_tags = []
+        self.uid_map = {}
+        print(self.dicom_data)
+
+        for element, _ in DicomRedactionPlan._iter_dicom_elements(self.dicom_data):
+            keyword = keyword_for_tag(element.tag)
+            keyword_in_rules = keyword in rules.metadata
+            if not keyword_in_rules:
+                self.no_match_tags.append(element.tag)
+                continue
+
+            rule = rules.metadata[keyword]
+            if rule.action in [
+                "keep",
+                "delete",
+                "replace",
+                "check_type",
+                "empty",
+                "replace_uid",
+                "replace_dummy",
+            ]:
+                self.metadata_redaction_steps[element.tag] = rule
+            else:
+                self.no_match_tags.append(element.tag)
+                continue
+
+    def passes_type_check(self, element: DataElement) -> bool:
+        return isinstance(element.value, VR_TO_EXPECTED_TYPE[element.VR])
+
+    def determine_redaction_operation(
+        self, rule: ConcreteMetadataRule, element: DataElement
+    ) -> RedactionOperation:
+        if rule.action == "check_type":
+            return "keep" if self.passes_type_check(element) else "delete"
+        if rule.action in ["keep", "delete", "replace", "replace_uid", "replace_dummy", "empty"]:
+            return rule.action
+        return "delete"
+
+    def report_plan(self) -> None:
+        logger.info("DICOM Metadata Redaction Plan\n")
+        print("DICOM Metadata Redaction Plan\n")
+        for element, _ in DicomRedactionPlan._iter_dicom_elements(self.dicom_data):
+            keyword = keyword_for_tag(element.tag)
+            rule = self.metadata_redaction_steps.get(element.tag, None)
+            if rule:
+                operation = self.determine_redaction_operation(rule, element)
+                logger.info(f"DICOM Tag {element.tag} - {keyword}: {operation}")
+                print(f"DICOM Tag {element.tag} - {keyword}: {operation}")
+        self.report_missing_rules()
+
+    def apply(self, rule: ConcreteMetadataRule, element: DataElement, dataset: Dataset):
+        operation = self.determine_redaction_operation(rule, element)
+        if operation == "delete":
+            # TODO make sure this works as expected, we are modifying a dataset
+            # while looping through it
+            del dataset[element.tag]
+        elif operation == "replace":
+            assert isinstance(rule, MetadataReplaceRule)
+            element.value = rule.new_value
+        elif operation == "empty":
+            element.value = None
+        elif operation == "replace_uid":
+            if element.value not in self.uid_map:
+                new_uid = "2.25." + str(uuid4().int)
+                self.uid_map[element.value] = str(new_uid)
+            element.value = self.uid_map[element.value]
+        elif operation == "replace_dummy":
+            element.value = VR_TO_DUMMY_VALUE[element.VR]
+
+    def execute_plan(self) -> None:
+        for element, dataset in DicomRedactionPlan._iter_dicom_elements(self.dicom_data):
+            rule = self.metadata_redaction_steps[element.tag]
+            if rule is not None:
+                self.apply(rule, element, dataset)
+
+    def is_comprehensive(self) -> bool:
+        return not self.no_match_tags
+
+    def report_missing_rules(self) -> None:
+        if self.is_comprehensive():
+            logger.info("The redaction plan is comprehensive.")
+        else:
+            logger.error("The following tags could not be redacted given the current set of rules.")
+            for tag in self.no_match_tags:
+                logger.error(f"Missing tag (dicom): {tag} - {keyword_for_tag(tag)}")
+
+    def save(self, output_path: Path, overwrite: bool) -> None:
+        if output_path.exists():
+            if overwrite:
+                logger.info(f"Found existing redaction for {self.image_path.name}. Overwriting...")
+            else:
+                logger.warn(
+                    f"Could not redact {self.image_path.name}, existing redacted file in output "
+                    "directory. Use the --overwrite-existing-output flag to overwrite previously "
+                    "redacted fiels."
+                )
+                return
+        self.dicom_data.save_as(output_path)

--- a/imagedephi/redact/dicom.py
+++ b/imagedephi/redact/dicom.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from pathlib import Path
-from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import pydicom
@@ -23,7 +22,7 @@ from imagedephi.utils.logger import logger
 
 from .redaction_plan import RedactionPlan
 
-VR_TO_DUMMY_VALUE = {}
+VR_TO_DUMMY_VALUE: dict[str, str | float | int | list | bytes] = {}
 for vr in valuerep.STR_VR:
     VR_TO_DUMMY_VALUE[vr] = ""
 for vr in valuerep.FLOAT_VR:
@@ -35,7 +34,7 @@ for vr in valuerep.LIST_VR:
 for vr in valuerep.BYTES_VR:
     VR_TO_DUMMY_VALUE[vr] = b""
 
-VR_TO_EXPECTED_TYPE = {}
+VR_TO_EXPECTED_TYPE: dict[str, type] = {}
 for vr in valuerep.STR_VR:
     VR_TO_EXPECTED_TYPE[vr] = str
 for vr in valuerep.FLOAT_VR:
@@ -45,7 +44,7 @@ for vr in valuerep.INT_VR:
 for vr in valuerep.LIST_VR:
     VR_TO_EXPECTED_TYPE[vr] = list
 for vr in valuerep.BYTES_VR:
-    VR_TO_DUMMY_VALUE[vr] = bytes
+    VR_TO_EXPECTED_TYPE[vr] = bytes
 
 
 class DicomRedactionPlan(RedactionPlan):

--- a/imagedephi/redact/dicom.py
+++ b/imagedephi/redact/dicom.py
@@ -66,7 +66,7 @@ class DicomRedactionPlan(RedactionPlan):
         dicom_dataset: Dataset,
     ) -> Generator[tuple[DataElement, Dataset], None, None]:
         for element in dicom_dataset:
-            if element.VR == "SQ":
+            if element.VR == valuerep.VR.SQ:
                 for dataset in element.value:
                     yield from DicomRedactionPlan._iter_dicom_elements(dataset)
                 # Treat the sequence as its own element as well.

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -40,11 +40,15 @@ def iter_image_files(directory: Path) -> Generator[Path, None, None]:
         # Use first four bits to check if its a tiff file
         if child.is_file():
             try:
-                data = open(child, "rb").read(4)
+                data = open(child, "rb").read(132)
             except PermissionError:
                 pass
             else:
-                if data in (b"II\x2a\x00", b"MM\x00\x2a", b"II\x2b\x00", b"MM\x00\x2b"):
+                if data[:4] in (b"II\x2a\x00", b"MM\x00\x2a", b"II\x2b\x00", b"MM\x00\x2b"):
+                    # tiff
+                    yield child
+                elif data[128:] == b"DICM":
+                    # dicom
                     yield child
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "hypercorn",
     "pyyaml",
     "Pillow",
+    "pydicom",
 ]
 dynamic = ["version"]
 

--- a/tests/data/input/dcm/test_dcm_image.dcm
+++ b/tests/data/input/dcm/test_dcm_image.dcm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc4058989bf0d0d669f9f4537378d1e6e658f3371bafee19d386ed257bc4fb9f
+size 18162578

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -116,7 +116,7 @@ def test_redact_dcm(dcm_input_path, tmp_path, override_rule_set):
 
     output_file = tmp_path / "Redacted_2023-05-12_12-12-53" / "my_study_slide_1.dcm"
     dcm_output_file_bytes = output_file.read_bytes()
-    # verify the custom rule was applied
+    # verify th ebase rule deleted "SeriesDescription"
     assert b"Sample" not in dcm_output_file_bytes
 
 


### PR DESCRIPTION
Here is the initial set of changes to support redacting DICOM images.

As a start, only metadata redaction is supported and only redaction of single .dcm files is supported.

(TODO before ready for full review/merge):

- [x] Add functional test
- [x] Clean up code (prints, misc. comments, etc