### PR TITLE
Add flag to skip renaming files

### DIFF
--- a/imagedephi/gui.py
+++ b/imagedephi/gui.py
@@ -63,7 +63,7 @@ app = FastAPI(
 templates = Jinja2Templates(
     # Jinja2Templates requires a "directory" argument, but it is effectively unused
     # if a custom loader is passed
-    directory="",
+    directory=".",
     loader=FunctionLoader(_load_template),
 )
 

--- a/imagedephi/main.py
+++ b/imagedephi/main.py
@@ -111,12 +111,21 @@ def imagedephi(
     help="Path where output directory will be created.",
     type=click.Path(exists=True, file_okay=False, readable=True, writable=True, path_type=Path),
 )
+@click.option("--rename/--skip-rename", default=True)
 @click.pass_obj
-def run(obj: ImagedephiContext, input_path: Path, output_dir: Path, verbose, quiet, log_file):
+def run(
+    obj: ImagedephiContext,
+    input_path: Path,
+    output_dir: Path,
+    rename: bool,
+    verbose,
+    quiet,
+    log_file,
+):
     """Perform the redaction of images."""
     if verbose or quiet or log_file:
         set_logging_config(verbose, quiet, log_file)
-    redact_images(input_path, output_dir, obj.override_rule_set)
+    redact_images(input_path, output_dir, obj.override_rule_set, rename)
 
 
 @imagedephi.command

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -69,6 +69,7 @@ def redact_images(
     input_path: Path,
     output_dir: Path,
     override_rules: Ruleset | None = None,
+    rename: bool = True,
     overwrite: bool = False,
 ) -> None:
     base_rules = get_base_rules()
@@ -96,12 +97,16 @@ def redact_images(
                     redaction_plan.report_missing_rules()
                 else:
                     redaction_plan.execute_plan()
-                    output_path = _get_output_path(
-                        image_file,
-                        redact_dir,
-                        output_file_name_base,
-                        output_file_counter,
-                        output_file_max,
+                    output_path = (
+                        _get_output_path(
+                            image_file,
+                            redact_dir,
+                            output_file_name_base,
+                            output_file_counter,
+                            output_file_max,
+                        )
+                        if rename
+                        else redact_dir / image_file.name
                     )
                     redaction_plan.save(output_path, overwrite)
                     if output_file_counter == output_file_max:

--- a/imagedephi/utils/logger.py
+++ b/imagedephi/utils/logger.py
@@ -9,7 +9,7 @@ try:
         if os.path.exists("logging.conf")
         else str(importlib.resources.files("imagedephi") / "logging.conf")
     )
-except KeyError:
+except (FileNotFoundError, KeyError):
     pass
 
 logger = logging.getLogger("root")

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -131,3 +131,23 @@ def test_e2e_help(cli_runner: CliRunner, help_flag: str) -> None:
 
     assert result.exit_code == 0
     assert "Usage: imagedephi" in result.output
+
+
+@freeze_time("2023-05-12 12:12:53")
+@pytest.mark.timeout(5)
+@pytest.mark.parametrize("rename", [True, False])
+def test_e2e_rename_flag(cli_runner, data_dir: Path, tmp_path: Path, rename: bool):
+    rename_flag = "--rename" if rename else "--skip-rename"
+    result = cli_runner.invoke(
+        main.imagedephi,
+        ["run", str(data_dir / "input" / "tiff"), "--output-dir", str(tmp_path), rename_flag],
+    )
+
+    assert result.exit_code == 0
+
+    output_file_name = (
+        tmp_path / "Redacted_2023-05-12_12-12-53" / "study_slide_1.tif"
+        if rename
+        else tmp_path / "Redacted_2023-05-12_12-12-53" / "test_image.tif"
+    )
+    assert output_file_name.exists()


### PR DESCRIPTION
Fix #171 

Add an option to the `run` command to keep original file names, in the case where users are confident that their image file names do not contain PHI but would be helpful to preserve after redaction.

To use: 

`imagedephi run path/to/images -o output/path --skip-rename`