### PR TITLE
Harden Jinja expectations and logger errors

### DIFF
--- a/imagedephi/gui.py
+++ b/imagedephi/gui.py
@@ -63,7 +63,7 @@ app = FastAPI(
 templates = Jinja2Templates(
     # Jinja2Templates requires a "directory" argument, but it is effectively unused
     # if a custom loader is passed
-    directory="",
+    directory=".",
     loader=FunctionLoader(_load_template),
 )
 

--- a/imagedephi/utils/logger.py
+++ b/imagedephi/utils/logger.py
@@ -9,7 +9,7 @@ try:
         if os.path.exists("logging.conf")
         else str(importlib.resources.files("imagedephi") / "logging.conf")
     )
-except KeyError:
+except (FileNotFoundError, KeyError):
     pass
 
 logger = logging.getLogger("root")


### PR DESCRIPTION
Some change in the last few weeks to fastapi has caused CI to start throwing errors.  Specifically fastapi<0.107 works, but 0.107 requires that the Jinja template directory parameter not be an empty string.