### PR TITLE
Allow redacting on subdirs

### DIFF
--- a/imagedephi/main.py
+++ b/imagedephi/main.py
@@ -112,12 +112,14 @@ def imagedephi(
     type=click.Path(exists=True, file_okay=False, readable=True, writable=True, path_type=Path),
 )
 @click.option("--rename/--skip-rename", default=True)
+@click.option("-r", "--recursive", is_flag=True, help="Redact images in subdirectories.")
 @click.pass_obj
 def run(
     obj: ImagedephiContext,
     input_path: Path,
     output_dir: Path,
     rename: bool,
+    recursive: bool,
     verbose,
     quiet,
     log_file,
@@ -125,7 +127,7 @@ def run(
     """Perform the redaction of images."""
     if verbose or quiet or log_file:
         set_logging_config(verbose, quiet, log_file)
-    redact_images(input_path, output_dir, obj.override_rule_set, rename)
+    redact_images(input_path, output_dir, obj.override_rule_set, rename, recursive=recursive)
 
 
 @imagedephi.command

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -80,7 +80,9 @@ def redact_images(
         override_rules.output_file_name if override_rules else base_rules.output_file_name
     )
     # Convert to a list in order to get the length
-    images_to_redact = list(iter_image_files(input_path, recursive) if input_path.is_dir() else [input_path])
+    images_to_redact = list(
+        iter_image_files(input_path, recursive) if input_path.is_dir() else [input_path]
+    )
     output_file_counter = 1
     output_file_max = len(images_to_redact)
     redact_dir = create_redact_dir(output_dir)
@@ -102,7 +104,9 @@ def redact_images(
                     redaction_plan.execute_plan()
                     output_parent_dir = redact_dir
                     if recursive:
-                        output_parent_dir = Path(str(image_file).replace(str(input_path), str(redact_dir), 1)).parent
+                        output_parent_dir = Path(
+                            str(image_file).replace(str(input_path), str(redact_dir), 1)
+                        ).parent
                         output_parent_dir.mkdir(parents=True, exist_ok=True)
                     output_path = (
                         _get_output_path(

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -117,7 +117,7 @@ def redact_images(
                             output_file_max,
                         )
                         if rename
-                        else redact_dir / image_file.name
+                        else output_parent_dir / image_file.name
                     )
                     redaction_plan.save(output_path, overwrite)
                     if output_file_counter == output_file_max:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -155,13 +155,20 @@ def test_e2e_rename_flag(cli_runner, data_dir: Path, tmp_path: Path, rename: boo
 
 @freeze_time("2024-01-04 10:48:00")
 @pytest.mark.timeout(5)
-@pytest.mark.parametrize("recursive", [True, False])
-def test_e2e_recursive(cli_runner, data_dir: Path, tmp_path: Path, recursive: bool):
+@pytest.mark.parametrize(
+    "recursive,rename", [(True, True), (True, False), (False, False), (False, True)]
+)
+def test_e2e_recursive(cli_runner, data_dir: Path, tmp_path: Path, recursive: bool, rename: bool):
     args = ["run", str(data_dir / "input"), "--output-dir", str(tmp_path)]
     if recursive:
         args.append("--recursive")
+    if rename:
+        args.append("--skip-rename")
     result = cli_runner.invoke(main.imagedephi, args)
 
     assert result.exit_code == 0
     output_subdir = tmp_path / "Redacted_2024-01-04_10-48-00" / "svs"
     assert output_subdir.exists() == recursive
+
+    if recursive:
+        assert len(list(output_subdir.iterdir()))

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -151,3 +151,17 @@ def test_e2e_rename_flag(cli_runner, data_dir: Path, tmp_path: Path, rename: boo
         else tmp_path / "Redacted_2023-05-12_12-12-53" / "test_image.tif"
     )
     assert output_file_name.exists()
+
+
+@freeze_time("2024-01-04 10:48:00")
+@pytest.mark.timeout(5)
+@pytest.mark.parametrize("recursive", [True, False])
+def test_e2e_recursive(cli_runner, data_dir: Path, tmp_path: Path, recursive: bool):
+    args = ["run", str(data_dir / "input"), "--output-dir", str(tmp_path)]
+    if recursive:
+        args.append("--recursive")
+    result = cli_runner.invoke(main.imagedephi, args)
+
+    assert result.exit_code == 0
+    output_subdir = tmp_path / "Redacted_2024-01-04_10-48-00" / "svs"
+    assert output_subdir.exists() == recursive


### PR DESCRIPTION
Fix #170 

Adds a new flag (`-r` or `--recursive`).

If this flag is provided to the `imagedephi run` command, then redaction will be performed on sub directories of the input directory. Additionally, the directory structure will be duplicated in the output directory.