### PR TITLE
Include dicom encoders in the binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build binary
         run: |
           tox -e binary
+      - name: Test binary runs
+        run: |
+          dist/imagedephi --help
       - name: Upload binary artifact
         uses: actions/upload-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If running on macOS, you may need to [add the executable to the list of trusted 
 Image redaction is determined by a set of rules. By default, the base set of rules are used. These rules are provided by the `imagedephi` package and can be found [here](https://github.com/DigitalSlideArchive/ImageDePHI/blob/main/imagedephi/base_rules.yaml).
 
 ## Rule Application
-All runs of `imagedephi` use the provided base set of rules as a foundation. End users can use the ruleset framework to buld custom rulesets that handle additional or custom metadata not covered by the base rules, or override the behavior of the base rule set.
+All runs of `imagedephi` use the provided base set of rules as a foundation. End users can use the ruleset framework to build custom rulesets that handle additional or custom metadata not covered by the base rules, or override the behavior of the base rule set.
 
 Override rule sets can be specified by using the `-r my_ruleset.yml` or `--override-rules my_ruleset.yml` option. This option is available for both the `imagedephi run` and `imagedephi plan` commands. Override rules sets are not provided by `imagedephi`, and must de defined by the end user.
 

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ commands =
         --name imagedephi \
         --recursive-copy-metadata imagedephi \
         --collect-data imagedephi \
+        --collect-submodules pydicom.encoders \
         --specpath {env_tmp_dir} \
         --workpath {env_tmp_dir} \
         {env_site_packages_dir}/imagedephi/__main__.py


### PR DESCRIPTION
Otherwise, the binary fails because it can read some modules it expects to be present.