### PR TITLE
Add types-Pillow to tox type test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ deps =
     mypy
     pytest
     types-PyYAML
+    types-Pillow
 commands =
     mypy {posargs:.}
 


### PR DESCRIPTION
`type` tests were failing, claiming falsely that `Image.LANCZOS` did not exist.