### PR TITLE
Explicitly use macos14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         os:
           # Use an older Linux: https://pyinstaller.org/en/stable/usage.html#making-gnu-linux-apps-forward-compatible
           - ubuntu-20.04
-          - macos-latest
+          - macos-14
           - windows-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Pins workflow runner to macos14  to address connectivity issues found in macos12. 