### PR TITLE
Write a csv summary of redaction runs

### DIFF
--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -67,7 +67,7 @@ def create_redact_dir(base_output_dir: Path, identifier: str | None = None) -> P
     """
     if not identifier:
         identifier = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    redact_dir = base_output_dir / f"Redacted_{time_stamp}"
+    redact_dir = base_output_dir / f"Redacted_{identifier}"
     try:
         redact_dir.mkdir(parents=True)
     except PermissionError:

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import OrderedDict, namedtuple
 from collections.abc import Generator
+from csv import DictWriter
 import datetime
 import importlib.resources
 from pathlib import Path
@@ -57,9 +58,8 @@ def iter_image_files(directory: Path, recursive: bool = False) -> Generator[Path
             yield from iter_image_files(child, recursive)
 
 
-def create_redact_dir(base_output_dir: Path) -> Path:
+def create_redact_dir(base_output_dir: Path, time_stamp: str) -> Path:
     """Given a directory, create and return a timestamped sub-directory within it."""
-    time_stamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     redact_dir = base_output_dir / f"Redacted_{time_stamp}"
     try:
         redact_dir.mkdir(parents=True)
@@ -79,6 +79,10 @@ def redact_images(
     overwrite: bool = False,
     recursive: bool = False,
 ) -> None:
+    # Keep track of information about this run to write to a persistent log file (csv?)
+    # (original_name, output_name) as bare minimum
+    # error message? rule set (base/override)?
+    run_summary = []
     base_rules = get_base_rules()
     output_file_name_base = (
         override_rules.output_file_name if override_rules else base_rules.output_file_name
@@ -89,7 +93,8 @@ def redact_images(
     )
     output_file_counter = 1
     output_file_max = len(images_to_redact)
-    redact_dir = create_redact_dir(output_dir)
+    time_stamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    redact_dir = create_redact_dir(output_dir, time_stamp)
 
     dcm_uid_map: dict[str, str] = {}
 
@@ -128,9 +133,24 @@ def redact_images(
                     else output_parent_dir / image_file.name
                 )
                 redaction_plan.save(output_path, overwrite)
+                run_summary.append(
+                    {
+                        "input_path": image_file,
+                        "output_path": output_path,
+                    }
+                )
                 if output_file_counter == output_file_max:
                     logger.info("Redactions completed")
             output_file_counter += 1
+    # Create manifest file using same timestamp as redact dir
+    manifest_file = output_dir / f"Redacted_{time_stamp}_manifest.csv"
+    logger.info(f"Writing manifest to {manifest_file}")
+    with open(manifest_file, "w") as manifest:
+        fieldnames = ["input_path", "output_path"]
+        writer = DictWriter(manifest, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in run_summary:
+            writer.writerow(row)
 
 
 def show_redaction_plan(

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -58,8 +58,15 @@ def iter_image_files(directory: Path, recursive: bool = False) -> Generator[Path
             yield from iter_image_files(child, recursive)
 
 
-def create_redact_dir(base_output_dir: Path, time_stamp: str) -> Path:
-    """Given a directory, create and return a timestamped sub-directory within it."""
+def create_redact_dir(base_output_dir: Path, identifier: str | None = None) -> Path:
+    """
+    Given a directory, create and return a sub-directory within it.
+
+    `identifier` should be a unique string for the new directory. If no value
+    is supplied, a timestamp is used.
+    """
+    if not identifier:
+        identifier = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     redact_dir = base_output_dir / f"Redacted_{time_stamp}"
     try:
         redact_dir.mkdir(parents=True)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -88,7 +88,7 @@ def test_e2e_gui(
     # Check that the GUI has stopped
     assert gui.poll() is not None
 
-    redacted_dirs = list(tmp_path.glob("*Redacted*"))
+    redacted_dirs = [path for path in tmp_path.glob("*Redacted*") if path.is_dir()]
     assert len(redacted_dirs) > 0
     redacted_files = list(redacted_dirs[0].glob("*"))
     assert len(redacted_files) > 0

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -163,3 +163,20 @@ def test_e2e_recursive(
 
     if recursive:
         assert len(list(output_subdir.iterdir()))
+
+
+@freeze_time("2024-01-04 10:48:00")
+@pytest.mark.timeout(5)
+def test_e2e_manifest(cli_runner, data_dir: Path, tmp_path: Path, test_image_tiff: Path):
+    args = ["run", str(data_dir / "input" / "tiff"), "--output-dir", str(tmp_path)]
+    result = cli_runner.invoke(main.imagedephi, args)
+
+    assert result.exit_code == 0
+    manifest_path = tmp_path / "Redacted_2024-01-04_10-48-00_manifest.csv"
+    assert manifest_path.exists()
+
+    output_file_name = tmp_path / "Redacted_2024-01-04_10-48-00" / "study_slide_1.tif"
+    assert output_file_name.exists()
+    manifest_file_bytes = manifest_path.read_bytes()
+    assert b"study_slide_1.tif" in manifest_file_bytes
+    assert str(test_image_tiff).encode() in manifest_file_bytes

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -7,7 +7,7 @@ import pytest
 import yaml
 
 from imagedephi import redact
-from imagedephi.redact.redact import create_redact_dir
+from imagedephi.redact.redact import create_redact_dir_and_manifest
 from imagedephi.redact.svs import SvsRedactionPlan
 from imagedephi.rules import Ruleset
 from imagedephi.utils.logger import logger
@@ -44,10 +44,12 @@ def dcm_input_path(data_dir, test_image_dcm, request) -> Path:
 
 
 @freeze_time("2023-05-12 12:12:53")
-def test_create_redact_dir(tmp_path):
-    output_dir = create_redact_dir(tmp_path / "fake")
+def test_create_redact_dir_and_manifest(tmp_path):
+    output_dir, manifest = create_redact_dir_and_manifest(tmp_path / "fake")
     assert output_dir.exists()
     assert output_dir.name == "Redacted_2023-05-12_12-12-53"
+    assert manifest.exists()
+    assert manifest.name == "Redacted_2023-05-12_12-12-53_manifest.csv"
 
 
 @freeze_time("2023-05-12 12:12:53")


### PR DESCRIPTION
Fix #220 

Create a file that is the sibling of the redacted directory. The file is a csv and contains a mapping of input file names to output file names.

This change replaces the `create_redact_dir` function with `create_redact_dir_and_manifest`, which functions nearly identically except it also creates (via `<path>.touch()`) the manifest file and returns a 2-value tuple `(output_dir, manifest_path)` where both values are paths. The test written for `create_redact_dir` has been updated to reflect this change.

TODO:

- [x] Write tests