### PR TITLE
Get thumbnails for non-tiled images

### DIFF
--- a/imagedephi/gui/api/api.py
+++ b/imagedephi/gui/api/api.py
@@ -67,12 +67,9 @@ def get_associated_image(file_name: str = "", image_key: str = ""):
         if image_key == "thumbnail":
             ifd = get_ifd_for_thumbnail(Path(file_name))
             if not ifd:
-                # TODO: support non-tiled thumbnails
-                # if image_key == "thumbnail":
-                #    ...
-                # If we can't find the lowest resolution IFD, try reading the image
-                # with PIL to generate a thumbnail
                 try:
+                    # If the image is not tiled, no appropriate IFD was found. In this case
+                    # attempt to get a thumbnail using the entire image.
                     return get_image_response_from_tiff(file_name)
                 except Exception as e:
                     raise HTTPException(

--- a/imagedephi/gui/api/api.py
+++ b/imagedephi/gui/api/api.py
@@ -74,10 +74,10 @@ def get_associated_image(file_name: str = "", image_key: str = ""):
                 # with PIL to generate a thumbnail
                 try:
                     return get_image_response_from_tiff(file_name)
-                finally:
+                except Exception as e:
                     raise HTTPException(
                         status_code=404,
-                        detail=f"Could not generate thumbnail image for {file_name}",
+                        detail=f"Could not generate thumbnail image for {file_name}: {e.args[0]}",
                     )
             return get_image_response_from_ifd(ifd, file_name)
 

--- a/imagedephi/gui/utils/image.py
+++ b/imagedephi/gui/utils/image.py
@@ -98,7 +98,13 @@ def get_image_response_from_tiff(file_name: str):
     """
     Use as a fallback when we can't find the best IFD for a thumbnail imate.
     This happens when attempting to extract a thumbnail from a non-tiled tiff.
+
+    Since we completely trust the input (images on the current machine), we disable
+    max image size. This should probably be revisited in the future if ImageDePHI needs
+    to work over the web.
     """
+    max_size = Image.MAX_IMAGE_PIXELS
+    Image.MAX_IMAGE_PIXELS = None
     jpeg_buffer = BytesIO()
     image = Image.open(file_name)
     scale_factor = MAX_ASSOCIATED_IMAGE_HEIGHT / image.size[1]
@@ -106,6 +112,7 @@ def get_image_response_from_tiff(file_name: str):
     image.thumbnail(new_size, Image.LANCZOS)
     image.save(jpeg_buffer, "JPEG")
     jpeg_buffer.seek(0)
+    Image.MAX_IMAGE_PIXELS = max_size
     return StreamingResponse(jpeg_buffer, media_type="image/jpeg")
 
 

--- a/imagedephi/gui/utils/image.py
+++ b/imagedephi/gui/utils/image.py
@@ -94,6 +94,21 @@ def get_image_response_from_ifd(ifd: "IFD", file_name: str):
             return StreamingResponse(jpeg_buffer, media_type="image/jpeg")
 
 
+def get_image_response_from_tiff(file_name: str):
+    """
+    Use as a fallback when we can't find the best IFD for a thumbnail imate.
+    This happens when attempting to extract a thumbnail from a non-tiled tiff.
+    """
+    jpeg_buffer = BytesIO()
+    image = Image.open(file_name)
+    scale_factor = MAX_ASSOCIATED_IMAGE_HEIGHT / image.size[1]
+    new_size = (int(image.size[0] * scale_factor), int(image.size[1] * scale_factor))
+    image.thumbnail(new_size, Image.LANCZOS)
+    image.save(jpeg_buffer, "JPEG")
+    jpeg_buffer.seek(0)
+    return StreamingResponse(jpeg_buffer, media_type="image/jpeg")
+
+
 def get_image_response_dicom(related_files: list[Path], key: str):
     slide = WsiDicom.open(related_files)
     image = None


### PR DESCRIPTION
Fix #219 

#### Changes

Add a fallback for obtaining thumbnail images for tiffs. In the case that no lowest-resolution tiled IFD can be found, pass the image path to a new function , `get_image_response_from_tiff`. This new function attempts to use `PIL` to open up the entire image and generate a JPEG thumbnail from there.

Note that this does require disabling the `MAX_IMAGE_PIXELS` for `PIL.Image` in this function, since non-tiled tiffs can still be quite large, and `PIL` will throw an exception if the number of image pixels exceeds a certain threshold. I believe this is safe for now, since the intended use case is redacting images local to the user's machine.

#### To test

1. Run `imagedephi gui` to start the web server
2. Open your browser to `localhost:<port>`, where `<port>` is the port where the web application is running
3. navigate to `/?file_name=<path/to/file>&image_key=thumbnail` where `<path/to/file>` is the full path to a non-tiled tiff image
4. You should see a thumbnail-sized image in your browser