### PR TITLE
Apply image size checks consistently

### DIFF
--- a/imagedephi/gui/api/api.py
+++ b/imagedephi/gui/api/api.py
@@ -73,10 +73,17 @@ def get_associated_image(file_name: str = "", image_key: str = ""):
                     return get_image_response_from_tiff(file_name)
                 except Exception as e:
                     raise HTTPException(
-                        status_code=404,
+                        status_code=422,  # unprocessable content
                         detail=f"Could not generate thumbnail image for {file_name}: {e.args[0]}",
                     )
-            return get_image_response_from_ifd(ifd, file_name)
+            else:
+                try:
+                    return get_image_response_from_ifd(ifd, file_name)
+                except Exception as e:
+                    raise HTTPException(
+                        status_code=422,  # unprocessable content
+                        detail=f"Could not generate thumbnail image for {file_name}: {e.args[0]}",
+                    )
 
         # image key is one of "macro", "label"
         if not get_is_svs(Path(file_name)):
@@ -89,7 +96,13 @@ def get_associated_image(file_name: str = "", image_key: str = ""):
             raise HTTPException(
                 status_code=404, detail=f"No {image_key} image found for {file_name}"
             )
-        return get_image_response_from_ifd(ifd, file_name)
+        try:
+            return get_image_response_from_ifd(ifd, file_name)
+        except Exception as e:
+            raise HTTPException(
+                status_code=422,  # unprocessable content
+                detail=f"Could not generate thumbnail image for {file_name}: {e.args[0]}",
+            )
     elif image_type == FileFormat.DICOM:
         path = Path(file_name)
         related_files = [

--- a/imagedephi/gui/utils/image.py
+++ b/imagedephi/gui/utils/image.py
@@ -72,6 +72,12 @@ def extract_thumbnail_from_image_bytes(ifd: "IFD", file_name: str) -> Image.Imag
 
 
 def get_image_response_from_ifd(ifd: "IFD", file_name: str):
+    # Make sure the image isn't too big
+    height = int(ifd["tags"][tifftools.Tag.ImageLength.value]["data"][0])
+    width = int(ifd["tags"][tifftools.Tag.ImageWidth.value]["data"][0])
+    if height * width > IMAGE_DEPHI_MAX_IMAGE_PIXELS:
+        raise Exception(f"{file_name} too large to create thumbnail")
+
     # use tifftools and PIL to create a jpeg of the associated image, sized for the browser
     tiff_buffer = BytesIO()
     jpeg_buffer = BytesIO()


### PR DESCRIPTION
Builds off of the max image pixels for Image DePHI introduced by #224.

Before attempting to read the IFD image data for the lowest res IFD, check its size. If the total number of pixels is > 1,000,000,000, throw an exception, and handle the exception appropriately in calling code.