### PR TITLE
The name of the photometric tag in tiff is photometric

### DIFF
--- a/imagedephi/minimum_rules.yaml
+++ b/imagedephi/minimum_rules.yaml
@@ -16,7 +16,7 @@ tiff:
       action: keep
     Compression:
       action: keep
-    PhotometricInterpretation:
+    Photometric:
       action: keep
     StripOffsets:
       action: keep
@@ -102,7 +102,7 @@ svs:
       action: keep
     Compression:
       action: keep
-    PhotometricInterpretation:
+    Photometric:
       action: keep
     StripOffsets:
       action: keep


### PR DESCRIPTION
In dicom it is PhotometricInterpretation.  We used the wrong one in the minimum rule set.