### PR TITLE
Yamlfix doesn't work with a recent package

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps =
     flake8-isort
     pep8-naming
     yamlfix
+    maison<2.0.0
 commands =
     flake8 {posargs:.}
     yamlfix -c pyproject.toml --exclude ./build/**/* --exclude ./client/node_modules/**/* . --check
@@ -31,6 +32,7 @@ deps =
     black
     isort
     yamlfix
+    maison<2.0.0
 commands =
     isort {posargs:.}
     black {posargs:.}


### PR DESCRIPTION
Pin maison so yamlfix will still work.  See issue 286 on yamlfix for details.  The pinned packages should be unpinned when that issue is addressed.