### PR TITLE
Add `strict` to rule sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,14 @@ You can add a description to your custom rulesets. This is not used by the progr
 #### `output_file_name`
 Specify how the output files should be named here. The base ruleset contains the value `study_slide`. In this case, if the input slides are named: `john_smith_lung.svs` and `john_smith_pancreas.svs`, the redacted output images will be named `study_slide_1.svs` and `study_slide_2.svs`.
 
+### Other Top-level Properties
+
+#### `strict`
+The `strict` property of rulesets is used to denote that ALL unspecified tags should be deleted. This is supported for `tiff` and `svs` files. An example of using the strict flag can be seen in the `minimum_rules.yaml` rule set.
+
 ### File Format Rules
 Redaction behavior is specified per file type. Currently pure `tiff` files, Aperio (`.svs`), and DICOM files are supported. Each image type has its own groups of data that can be redacted. For example, Aperio images have `tiff` metadata, certain associated images, and additional metadata specified in the `ImageDescription` tag. `svs` rulesets take the following shape:
+
 
 ```yaml
 svs:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Image redaction is determined by a set of rules. By default, the base set of rul
 ## Rule Application
 All runs of `imagedephi` use the provided base set of rules as a foundation. End users can use the ruleset framework to build custom rulesets that handle additional or custom metadata not covered by the base rules, or override the behavior of the base rule set.
 
-Override rule sets can be specified by using the `-r my_ruleset.yaml` or `--override-rules my_ruleset.yaml` option. This option is available for both the `imagedephi run` and `imagedephi plan` commands. Override rules sets are not provided by `imagedephi`, and must de defined by the end user.
+Override rule sets can be specified by using the `-R my_ruleset.yaml` or `--override-rules my_ruleset.yaml` option. This option is available for both the `imagedephi run` and `imagedephi plan` commands. Override rules sets are not provided by `imagedephi`, and must de defined by the end user.
 
 When `imagedephi` determines the steps to redact a file, it checks each piece of metadata in the file. For each piece of metadata found this way, it will first consult the override rule set, if present, for an applicable rule. If the override rule set does not contain a rule for that piece of metadata, the program will check the base ruleset.
 

--- a/imagedephi/minimum_rules.yaml
+++ b/imagedephi/minimum_rules.yaml
@@ -2,6 +2,7 @@
 name: Minimum Rules
 description: A set of rules that defines a minimum amount of metadata for images to be read. Metadata not specified by a rule is deleted (controlled by the metadata_fallback_action).
 output_file_name: study_slide
+strict: true
 tiff:
   metadata_fallback_action: delete
   associated_images:

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -130,7 +130,9 @@ def redact_images(
     with logging_redirect_tqdm(loggers=[logger]):
         for image_file in tqdm(images_to_redact, desc="Redacting images", position=0, leave=True):
             push_progress(output_file_counter, output_file_max, redact_dir)
-            strict = profile == ProfileChoice.Strict.value
+            strict = (
+                override_rules.strict if override_rules else (profile == ProfileChoice.Strict.value)
+            )
             try:
                 redaction_plan = build_redaction_plan(
                     image_file, base_rules, override_rules, dcm_uid_map=dcm_uid_map, strict=strict

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -130,12 +130,9 @@ def redact_images(
     with logging_redirect_tqdm(loggers=[logger]):
         for image_file in tqdm(images_to_redact, desc="Redacting images", position=0, leave=True):
             push_progress(output_file_counter, output_file_max, redact_dir)
-            strict = (
-                override_rules.strict if override_rules else (profile == ProfileChoice.Strict.value)
-            )
             try:
                 redaction_plan = build_redaction_plan(
-                    image_file, base_rules, override_rules, dcm_uid_map=dcm_uid_map, strict=strict
+                    image_file, base_rules, override_rules, dcm_uid_map=dcm_uid_map
                 )
             # Handle and report other errors without stopping the process
             except Exception as e:
@@ -244,7 +241,6 @@ def show_redaction_plan(
 ) -> NamedTuple:
     image_paths = iter_image_files(input_path, recursive) if input_path.is_dir() else [input_path]
     base_rules = get_base_rules(profile)
-    strict = profile == ProfileChoice.Strict.value
 
     global tags_used
 
@@ -252,9 +248,7 @@ def show_redaction_plan(
         global redaction_plan_report
         for image_path in image_paths:
             try:
-                redaction_plan = build_redaction_plan(
-                    image_path, base_rules, override_rules, strict=strict
-                )
+                redaction_plan = build_redaction_plan(image_path, base_rules, override_rules)
             except tifftools.TifftoolsError:
                 logger.error(f"Could not open {image_path.name} as a tiff.")
                 continue

--- a/imagedephi/rules.py
+++ b/imagedephi/rules.py
@@ -169,6 +169,7 @@ class Ruleset(BaseModel):
     name: str = "My Rules"
     description: str = "My rules"
     output_file_name: str = "study_slide"
+    strict: bool = False
     tiff: TiffRules = TiffRules()
     svs: SvsRules = SvsRules()
     dicom: DicomRules = DicomRules()


### PR DESCRIPTION
### Changes
Previously, "strict" redaction was done only by specifying a redaction profile from the command line. Now, rule sets themselves can be flagged as `strict`.

Effectively, this means that there is now no difference between running 

`imagedephi --profile strict ...` 
and 
`imagedephi -R minimum_rules.yaml ...`

Users can now create their own "strict" rule sets using this flag, and all tags not specified by that rule set would be deleted.

Documentation has been updated and a new test has been added.