### PR TITLE
Handle missing rules

### DIFF
--- a/client/src/HomePage.vue
+++ b/client/src/HomePage.vue
@@ -77,13 +77,23 @@ const redact_images = async () => {
   }
 };
 
-const checkMissingRules = () => {
+const canRedact = () => {
+  if (
+    !selectedDirectories.value.inputDirectory ||
+    !selectedDirectories.value.outputDirectory
+  ) {
+    return;
+  }
   if (useRedactionPlan.imageRedactionPlan.missing_rules) {
     missingRulesModal.value.showModal();
-  }
-  else {
+  } else {
     redact_images();
   }
+};
+// If the user chooses to redact with missing rules, force redaction
+const forceRedact = () => {
+  missingRulesModal.value.close();
+  redact_images();
 };
 </script>
 
@@ -147,7 +157,7 @@ const checkMissingRules = () => {
               type="submit"
               :class="`${!selectedDirectories.inputDirectory || !selectedDirectories.outputDirectory ? 'btn btn-block bg-accent text-white uppercase rounded-lg tooltip' : 'btn btn-block btn-accent text-white uppercase rounded-lg'}`"
               data-tip="Please select input and output directories"
-              @click="checkMissingRules()"
+              @click="canRedact()"
             >
               De-phi Images
             </button>
@@ -159,29 +169,33 @@ const checkMissingRules = () => {
       <div class="modal-box max-w-96">
         <div class="card max-w-96">
           <div class="card-body">
-            <h2 class="font-bold text-xl text-center">Missing Redaction Rules</h2>
+            <h2 class="font-bold text-xl text-center">
+              Missing Redaction Rules
+            </h2>
             <div class="divider my-1"></div>
             <p class="indent-8 font-medium">
-              One or more images are missing redaction rules. If you continue these images will not be redacted.
+              One or more images are missing redaction rules. If you continue
+              these images will not be redacted.
             </p>
             <p class="indent-8 text-base font-medium">
-              To add rules, please select a ruleset with the missing redaction rules.
+              To add rules, please select a ruleset with the missing redaction
+              rules.
             </p>
           </div>
           <div class="card-actions flex-nowrap justify-between">
-          <button
-            class="btn btn-primary w-1/2 uppercase"
-            @click="missingRulesModal.close();"
-          >
-            Continue
-          </button>
-          <button
-            class="btn btn-neutral w-1/2 uppercase"
-            @click="missingRulesModal.close();"
-          >
-            Cancel
-          </button>
-        </div>
+            <button
+              class="btn btn-primary w-1/2 uppercase"
+              @click="forceRedact()"
+            >
+              Continue
+            </button>
+            <button
+              class="btn btn-neutral w-1/2 uppercase"
+              @click="missingRulesModal.close()"
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       </div>
     </dialog>

--- a/client/src/HomePage.vue
+++ b/client/src/HomePage.vue
@@ -166,8 +166,8 @@ const forceRedact = () => {
       </div>
     </div>
     <dialog id="missingRulesModal" ref="missingRulesModal" class="modal">
-      <div class="modal-box max-w-96">
-        <div class="card max-w-96">
+      <div class="modal-box max-w-100">
+        <div class="card max-w-100">
           <div class="card-body">
             <h2 class="font-bold text-xl text-center">
               Missing Redaction Rules
@@ -184,13 +184,13 @@ const forceRedact = () => {
           </div>
           <div class="card-actions flex-nowrap justify-between">
             <button
-              class="btn btn-primary w-1/2 uppercase"
+              class="btn btn-accent w-1/2 text-white uppercase"
               @click="forceRedact()"
             >
               Continue
             </button>
             <button
-              class="btn btn-neutral w-1/2 uppercase"
+              class="btn btn-neutral text-white w-1/2 uppercase"
               @click="missingRulesModal.close()"
             >
               Cancel

--- a/client/src/HomePage.vue
+++ b/client/src/HomePage.vue
@@ -71,6 +71,7 @@ const redact_images = async () => {
     });
     redactionStateFlags.value.redacting = false;
     redactionModal.value.close();
+    redactionStateFlags.value.showImageTable = false;
     redactionStateFlags.value.redactionComplete =
       !!useRedactionPlan.imageRedactionPlan.total;
     redactionStateFlags.value.redactionSnackbar = true;

--- a/client/src/HomePage.vue
+++ b/client/src/HomePage.vue
@@ -14,6 +14,7 @@ const inputModal = ref(null);
 const outputModal = ref(null);
 const rulesetModal = ref(null);
 const redactionModal = ref();
+const missingRulesModal = ref();
 
 const progress = ref({
   count: 0,
@@ -73,6 +74,15 @@ const redact_images = async () => {
     redactionStateFlags.value.redactionComplete =
       !!useRedactionPlan.imageRedactionPlan.total;
     redactionStateFlags.value.redactionSnackbar = true;
+  }
+};
+
+const checkMissingRules = () => {
+  if (useRedactionPlan.imageRedactionPlan.missing_rules) {
+    missingRulesModal.value.showModal();
+  }
+  else {
+    redact_images();
   }
 };
 </script>
@@ -137,7 +147,7 @@ const redact_images = async () => {
               type="submit"
               :class="`${!selectedDirectories.inputDirectory || !selectedDirectories.outputDirectory ? 'btn btn-block bg-accent text-white uppercase rounded-lg tooltip' : 'btn btn-block btn-accent text-white uppercase rounded-lg'}`"
               data-tip="Please select input and output directories"
-              @click="redact_images()"
+              @click="checkMissingRules()"
             >
               De-phi Images
             </button>
@@ -145,6 +155,37 @@ const redact_images = async () => {
         </div>
       </div>
     </div>
+    <dialog id="missingRulesModal" ref="missingRulesModal" class="modal">
+      <div class="modal-box max-w-96">
+        <div class="card max-w-96">
+          <div class="card-body">
+            <h2 class="font-bold text-xl text-center">Missing Redaction Rules</h2>
+            <div class="divider my-1"></div>
+            <p class="indent-8 font-medium">
+              One or more images are missing redaction rules. If you continue these images will not be redacted.
+            </p>
+            <p class="indent-8 text-base font-medium">
+              To add rules, please select a ruleset with the missing redaction rules.
+            </p>
+          </div>
+          <div class="card-actions flex-nowrap justify-between">
+          <button
+            class="btn btn-primary w-1/2 uppercase"
+            @click="missingRulesModal.close();"
+          >
+            Continue
+          </button>
+          <button
+            class="btn btn-neutral w-1/2 uppercase"
+            @click="missingRulesModal.close();"
+          >
+            Cancel
+          </button>
+        </div>
+        </div>
+      </div>
+    </dialog>
+
     <dialog id="redactionModal" ref="redactionModal" class="modal">
       <div class="modal-box w-96">
         <div class="card">

--- a/client/src/store/types.ts
+++ b/client/src/store/types.ts
@@ -18,6 +18,7 @@ export type imagePlanResponse = {
   data: Record<string, Record<string, string>>;
   total: number;
   tags: string[];
+  missing_rules: boolean;
 };
 
 export interface Path {

--- a/imagedephi/main.py
+++ b/imagedephi/main.py
@@ -125,6 +125,7 @@ def imagedephi(
 @imagedephi.command(no_args_is_help=True)
 @global_options
 @click.argument("input-path", type=click.Path(exists=True, readable=True, path_type=Path))
+@click.option("-i", "--index", default=1, help="Starting index of the images to redact.", type=int)
 @click.option(
     "-o",
     "--output-dir",
@@ -146,6 +147,7 @@ def run(
     quiet,
     verbose,
     log_file,
+    index,
 ):
     """Perform the redaction of images."""
     params = _check_parent_params(ctx, profile, override_rules, recursive, quiet, verbose, log_file)
@@ -158,6 +160,7 @@ def run(
         rename=rename,
         recursive=params["recursive"],
         profile=params["profile"],
+        index=index,
     )
 
 

--- a/imagedephi/main.py
+++ b/imagedephi/main.py
@@ -122,7 +122,7 @@ def imagedephi(
         set_logging_config(verbose, quiet, log_file)
 
 
-@imagedephi.command
+@imagedephi.command(no_args_is_help=True)
 @global_options
 @click.argument("input-path", type=click.Path(exists=True, readable=True, path_type=Path))
 @click.option(
@@ -161,7 +161,7 @@ def run(
     )
 
 
-@imagedephi.command
+@imagedephi.command(no_args_is_help=True)
 @global_options
 @click.argument("input-path", type=click.Path(exists=True, readable=True, path_type=Path))
 @click.pass_context

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -250,8 +250,9 @@ def redact_images(
                         failed_dir.rmdir()
             index += 1
             output_file_counter += 1
-    with open(failed_manifest_file, "a") as manifest:
-        manifest.write("failed_images_count: " + str(failed_img_counter) + "\n")
+    if failed_img_counter:
+        with open(failed_manifest_file, "a") as manifest:
+            manifest.write("failed_images_count: " + str(failed_img_counter) + "\n")
     logger.info(f"Writing manifest to {manifest_file}")
     with open(manifest_file, "w") as manifest:
         fieldnames = ["input_path", "output_path", "detail"]

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -251,10 +251,16 @@ def redact_images(
                     if failed_img_counter:
                         # Ensure that the logged index is the correct starting point
                         index += 1
+                        yaml_command = f"""command: >
+                              imagedephi run
+                              {failed_dir}\\
+                              --output-dir {redact_dir}\\
+                              --index {index}\\"""
+
+                        command = yaml.safe_load(yaml_command)
                         with open(failed_manifest_file, "a") as manifest:
-                            manifest.write(
-                                f"command: imagedephi run {failed_dir} --index {index}\n"
-                            )
+                            yaml.dump(command, manifest)
+
                     else:
                         failed_manifest_file.unlink()
                         failed_dir.rmdir()

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -278,7 +278,14 @@ def redact_images(
                             index += 1
 
                             yaml_command = f"""command: imagedephi run {failed_dir} --output-dir {redact_dir.parent} --index {index}"""  # noqa
-
+                            options = [
+                                f" --override-rules {override_rules}" if override_rules else "",
+                                " --overwrite" if overwrite else "",
+                                f" --profile {profile}" if profile != "default" else "",
+                                " --recursive" if recursive else "",
+                                " --skip-rename" if not rename else "",
+                            ]
+                            yaml_command += " ".join(filter(None, options))
                             command = yaml.safe_load(yaml_command)
                             yaml.dump(command, manifest, width=float("inf"))
                 index += 1

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -165,7 +165,7 @@ def redact_images(
     )
 
     with open(failed_manifest_file, "w") as manifest:
-        manifest.write("failed_images:\n")
+        manifest.write("---\nfailed_images: \n")
 
     dcm_uid_map: dict[str, str] = {}
 
@@ -196,13 +196,13 @@ def redact_images(
                 failed_file.hardlink_to(image_file)
                 failed_img_counter += 1
                 with open(failed_manifest_file, "a") as manifest:
-                    manifest.write(f"\t - {image_file.name} \n \t\t missing_tags: \n")
+                    manifest.write(f"  - {image_file.name}: \n    missing_tags: \n")
                     missing_tags = redaction_plan.report_plan()[image_file.name].get(
                         "missing_tags", []
                     )
                     if isinstance(missing_tags, list):
                         for rule in missing_tags:
-                            manifest.write(f"\t\t\t - {rule}\n")
+                            manifest.write(f"      - {rule}\n")
                 run_summary.append(
                     {
                         "input_path": image_file,

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -241,6 +241,8 @@ def redact_images(
                 if output_file_counter == output_file_max:
                     logger.info("Redactions completed")
                     if failed_img_counter:
+                        # Ensure that the logged index is the correct starting point
+                        index += 1
                         with open(failed_manifest_file, "a") as manifest:
                             manifest.write(
                                 f"command: imagedephi run {failed_dir} --index {index}\n"
@@ -248,7 +250,7 @@ def redact_images(
                     else:
                         failed_manifest_file.unlink()
                         failed_dir.rmdir()
-            index += 1
+                index += 1
             output_file_counter += 1
     if failed_img_counter:
         with open(failed_manifest_file, "a") as manifest:

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -276,14 +276,11 @@ def redact_images(
                             )
                             manifest.write("failed_images_count: " + str(failed_img_counter) + "\n")
                             index += 1
-                            yaml_command = f"""command: >
-                                imagedephi run
-                                {failed_dir}\\
-                                --output-dir {redact_dir}\\
-                                --index {index}\\"""
+
+                            yaml_command = f"""command: imagedephi run {failed_dir} --output-dir {redact_dir.parent} --index {index}"""  # noqa
 
                             command = yaml.safe_load(yaml_command)
-                            yaml.dump(command, manifest)
+                            yaml.dump(command, manifest, width=float("inf"))
                 index += 1
             output_file_counter += 1
     logger.info(f"Writing manifest to {manifest_file}")

--- a/imagedephi/redact/redact.py
+++ b/imagedephi/redact/redact.py
@@ -8,6 +8,7 @@ from enum import Enum
 import importlib.resources
 import logging
 from pathlib import Path
+from shutil import copy2
 from typing import NamedTuple, TypeVar
 
 import tifftools
@@ -193,7 +194,9 @@ def redact_images(
             if not redaction_plan.is_comprehensive():
                 logger.info(f"Redaction could not be performed for {image_file.name}.")
                 failed_file = failed_dir / image_file.name
-                failed_file.hardlink_to(image_file)
+                # Using copy2 preserves metadata
+                # https://docs.python.org/3/library/shutil.html#shutil.copy2
+                copy2(image_file, failed_file)
                 failed_img_counter += 1
                 with open(failed_manifest_file, "a") as manifest:
                     manifest.write(f"  - {image_file.name}: \n    missing_tags: \n")

--- a/imagedephi/redact/redaction_plan.py
+++ b/imagedephi/redact/redaction_plan.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
     TagRedactionPlan = dict[str, int | float | TagData | ByteInfo]
 
-    RedactionPlanReport = dict[str, dict[str, int | str | TagRedactionPlan]]
+    RedactionPlanReport = dict[str, dict[str, int | str | list[str] | TagRedactionPlan]]
 
 
 class RedactionPlan:

--- a/imagedephi/redact/svs.py
+++ b/imagedephi/redact/svs.py
@@ -233,23 +233,27 @@ class SvsRedactionPlan(TiffRedactionPlan):
                     logger.debug(f"SVS Image Description - {key_name}: {operation}")
                     report[self.image_path.name][key_name] = {"action": operation, "value": _data}
                 continue
-            rule = self.metadata_redaction_steps[tag.value]
-            operation = self.determine_redaction_operation(rule, ifd)
-            logger.debug(f"Tiff Tag {tag.value} - {rule.key_name}: {operation}")
-            if ifd["tags"][tag.value]["datatype"] == tifftools.constants.Datatype.UNDEFINED.value:
-                encoded_value: dict[str, str | int] = {
-                    "value": f"0x{binascii.hexlify(ifd['tags'][tag.value]['data'] ).decode('utf-8')}",  # type: ignore # noqa: E501
-                    "bytes": len(ifd["tags"][tag.value]["data"]),
-                }
-                report[self.image_path.name][rule.key_name] = {
-                    "action": operation,
-                    "binary": encoded_value,
-                }
-            else:
-                report[self.image_path.name][rule.key_name] = {
-                    "action": operation,
-                    "value": ifd["tags"][tag.value]["data"],
-                }
+            if tag.value not in self.no_match_tags:
+                rule = self.metadata_redaction_steps[tag.value]
+                operation = self.determine_redaction_operation(rule, ifd)
+                logger.debug(f"Tiff Tag {tag.value} - {rule.key_name}: {operation}")
+                if (
+                    ifd["tags"][tag.value]["datatype"]
+                    == tifftools.constants.Datatype.UNDEFINED.value
+                ):
+                    encoded_value: dict[str, str | int] = {
+                        "value": f"0x{binascii.hexlify(ifd['tags'][tag.value]['data'] ).decode('utf-8')}",  # type: ignore # noqa: E501
+                        "bytes": len(ifd["tags"][tag.value]["data"]),
+                    }
+                    report[self.image_path.name][rule.key_name] = {
+                        "action": operation,
+                        "binary": encoded_value,
+                    }
+                else:
+                    report[self.image_path.name][rule.key_name] = {
+                        "action": operation,
+                        "value": ifd["tags"][tag.value]["data"],
+                    }
         self.report_missing_rules(report)
         logger.debug("Aperio (.svs) Associated Image Redaction Plan\n")
         # Report the number of associated images found in the image that match each associated

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -59,11 +59,17 @@ def tiff_input_path(data_dir, test_image_tiff, request) -> Path:
 
 @freeze_time("2023-05-12 12:12:53")
 def test_create_redact_dir_and_manifest(tmp_path):
-    output_dir, manifest = create_redact_dir_and_manifest(tmp_path / "fake")
+    output_dir, manifest, failed_dir, failed_manifest = create_redact_dir_and_manifest(
+        tmp_path / "fake"
+    )
     assert output_dir.exists()
     assert output_dir.name == "Redacted_2023-05-12_12-12-53"
     assert manifest.exists()
     assert manifest.name == "Redacted_2023-05-12_12-12-53_manifest.csv"
+    assert failed_dir.exists()
+    assert failed_dir.name == "Failed_2023-05-12_12-12-53"
+    assert failed_manifest.exists()
+    assert failed_manifest.name == "Failed_2023-05-12_12-12-53_manifest.csv"
 
 
 @freeze_time("2023-05-12 12:12:53")

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -1,3 +1,4 @@
+import datetime
 import importlib.resources
 import logging
 from pathlib import Path, PurePath
@@ -59,17 +60,12 @@ def tiff_input_path(data_dir, test_image_tiff, request) -> Path:
 
 @freeze_time("2023-05-12 12:12:53")
 def test_create_redact_dir_and_manifest(tmp_path):
-    output_dir, manifest, failed_dir, failed_manifest = create_redact_dir_and_manifest(
-        tmp_path / "fake"
-    )
+    time_stamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    output_dir, manifest = create_redact_dir_and_manifest(tmp_path / "fake", time_stamp)
     assert output_dir.exists()
     assert output_dir.name == "Redacted_2023-05-12_12-12-53"
     assert manifest.exists()
     assert manifest.name == "Redacted_2023-05-12_12-12-53_manifest.csv"
-    assert failed_dir.exists()
-    assert failed_dir.name == "Failed_2023-05-12_12-12-53"
-    assert failed_manifest.exists()
-    assert failed_manifest.name == "Failed_2023-05-12_12-12-53_manifest.yaml"
 
 
 @freeze_time("2023-05-12 12:12:53")

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -69,7 +69,7 @@ def test_create_redact_dir_and_manifest(tmp_path):
     assert failed_dir.exists()
     assert failed_dir.name == "Failed_2023-05-12_12-12-53"
     assert failed_manifest.exists()
-    assert failed_manifest.name == "Failed_2023-05-12_12-12-53_manifest.csv"
+    assert failed_manifest.name == "Failed_2023-05-12_12-12-53_manifest.yaml"
 
 
 @freeze_time("2023-05-12 12:12:53")


### PR DESCRIPTION
Closes #236 
Closes #237 

**Backend Changes**
- Created a failed directory and failed manifest file at start of redaction
- Each failed image is copied to the failed directory and logged to the manifest
- At the end of the redaction the command needed to re-redact the failed images is logged to the manifest
- Adds an index option to `run` command that indicates the starting number for renaming during redaction
- Originally if an image was skipped, the image counter would increase and thus, that number would be skipped in naming. => Now there is an additional counter that increases on successes.

![Screenshot from 2024-10-07 12-27-21](https://github.com/user-attachments/assets/12862de2-f98b-454f-944d-f66e5d33a7a6)



**Frontend Changes**
- Adds a confirmation Modal when an image set has images with missing rules 
- Continue forces redaction as described above
- Cancel closes the modal and allows the user to add a ruleset.
- A new image plan is generated when a rulest is added/removed


![image](https://github.com/user-attachments/assets/b6e01c15-a7d4-4aee-9378-60a99c46fc54)
