### PR TITLE
Ping from frontend and reduce delay in messaging

### DIFF
--- a/client/src/HomePage.vue
+++ b/client/src/HomePage.vue
@@ -38,6 +38,13 @@ ws.onmessage = (event) => {
     redact_dir: data.redact_dir || progress.value.redact_dir, // don't update if not present
   };
 };
+// Periodically ping the websocket
+
+setInterval(() => {
+  if (ws.readyState === ws.OPEN) {
+  ws.send("ping");
+}
+}, 5000);
 
 const redact_images = async () => {
   if (!selectedDirectories.value.inputDirectory || !selectedDirectories.value.outputDirectory) {

--- a/imagedephi/gui/api/api.py
+++ b/imagedephi/gui/api/api.py
@@ -172,16 +172,6 @@ def redact(
         redact_images(input_path, output_path)
 
 
-async def ws_heartbeat(websocket: WebSocket):
-    while True:
-        try:
-            await websocket.send_json("heartbeat")
-            await asyncio.sleep(10)
-        except WebSocketDisconnect:
-            print("Client disconnected")
-            break
-
-
 @router.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
     await websocket.accept()
@@ -192,7 +182,6 @@ async def websocket_endpoint(websocket: WebSocket):
             print("Client connected")
             backoff = 1
 
-            asyncio.create_task(ws_heartbeat(websocket))
             while True:
                 message = get_next_progress_message()
                 if message is not None:
@@ -201,7 +190,8 @@ async def websocket_endpoint(websocket: WebSocket):
                     )
                     await websocket.send_json(message_dict)
                 else:
-                    await asyncio.sleep(1)  # Add a small delay to avoid busy waiting
+                    await asyncio.sleep(0.001)  # Add a small delay to avoid busy waiting
+
         except WebSocketDisconnect:
             print("Attempting to reconnect to client")
             await asyncio.sleep(backoff)


### PR DESCRIPTION
Fixes #251 
Modelling after vite's [websocket](https://github.com/vitejs/vite/blob/587ad7b17beba50279eaf46b06c5bf5559c4f36e/packages/vite/src/client/client.ts#L175-L187) architecture, this implements a very simplified version:

- Periodically 'pinging' server
- Removes the server side 'heartbeat' 
- Reduces messaging delay (This is the most simplified portion since vite's HMR looks for changes in modules)