### PR TITLE
Harden global options

### DIFF
--- a/imagedephi/gui/api/api.py
+++ b/imagedephi/gui/api/api.py
@@ -7,7 +7,6 @@ import urllib.parse
 
 from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.responses import FileResponse
-import yaml
 
 from imagedephi.gui.utils.constants import MAX_ASSOCIATED_IMAGE_SIZE
 from imagedephi.gui.utils.directory import DirectoryData
@@ -17,7 +16,7 @@ from imagedephi.gui.utils.image import (
     get_image_response_from_tiff,
 )
 from imagedephi.redact import redact_images, show_redaction_plan
-from imagedephi.rules import FileFormat, Ruleset
+from imagedephi.rules import FileFormat
 from imagedephi.utils.dicom import file_is_same_series_as
 from imagedephi.utils.image import get_file_format_from_path
 from imagedephi.utils.progress_log import get_next_progress_message
@@ -143,11 +142,9 @@ def get_redaction_plan(
         raise HTTPException(status_code=404, detail="Input directory not found")
 
     if rules_path:
-        with open(rules_path, "r") as f:
-            override_rules = Ruleset.model_validate(yaml.safe_load(f))
-            return show_redaction_plan(
-                input_path, override_rules=override_rules, limit=limit, offset=offset, update=update
-            )._asdict()
+        return show_redaction_plan(
+            input_path, override_rules=Path(rules_path), limit=limit, offset=offset, update=update
+        )._asdict()
 
     return show_redaction_plan(input_path, limit=limit, offset=offset, update=update)._asdict()
 
@@ -165,9 +162,7 @@ def redact(
     if not output_path.is_dir():
         raise HTTPException(status_code=404, detail="Output directory not found")
     if rules_path:
-        with open(rules_path, "r") as f:
-            override_rules = Ruleset.model_validate(yaml.safe_load(f))
-            redact_images(input_path, output_path, override_rules)
+        redact_images(input_path, output_path, override_rules=Path(rules_path))
     else:
         redact_images(input_path, output_path)
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -22,19 +22,19 @@ def test_e2e_run(
     result = cli_runner.invoke(
         main.imagedephi,
         [
-            "--override-rules",
-            str(rules_dir / "example_user_rules.yaml"),
             "run",
             str(data_dir / "input" / "tiff"),
             "--output-dir",
             str(tmp_path),
+            "-R",
+            str(rules_dir / "example_user_rules.yaml"),
         ],
     )
-
     assert result.exit_code == 0
-    output_file = tmp_path / "Redacted_2023-05-12_12-12-53" / "study_slide_1.tif"
+    output_file = tmp_path / "Redacted_2023-05-12_12-12-53" / "my_study_slide_1.tif"
     output_file_bytes = output_file.read_bytes()
     assert b"large_image_converter" not in output_file_bytes
+    assert b"Redacted by ImageDePHI" in output_file_bytes
 
 
 @freeze_time("2024-05-20 11:46:00")

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -32,10 +32,9 @@ def test_e2e_run(
     )
 
     assert result.exit_code == 0
-    output_file = tmp_path / "Redacted_2023-05-12_12-12-53" / "my_study_slide_1.tif"
+    output_file = tmp_path / "Redacted_2023-05-12_12-12-53" / "study_slide_1.tif"
     output_file_bytes = output_file.read_bytes()
     assert b"large_image_converter" not in output_file_bytes
-    assert b"Redacted by ImageDePHI" in output_file_bytes
 
 
 @freeze_time("2024-05-20 11:46:00")


### PR DESCRIPTION
Fixes #261 
Fixes #262 

- Changes Override_rules to be a global option
- Changes Override_rules type to Path and validates the ruleset later on
- Checks the parent param for every global option so as not to overwrite it