### PR TITLE
Show help text for unknown subcommands

### DIFF
--- a/imagedephi/utils/cli.py
+++ b/imagedephi/utils/cli.py
@@ -44,5 +44,13 @@ class FallthroughGroup(click.Group):
                 # Execute the normal Click "no_args_is_help" behavior
                 click.echo(ctx.get_help(), color=ctx.color)
                 ctx.exit()
+        elif ctx.protected_args and ctx.protected_args[0] not in self.commands:
+            # If the subcommand stored in "ctx.protected_args" is not a real
+            # subcommand, show the entire help text in addition to the "no such
+            # command" mesasge.
+            click.echo(f"Error: No such command: '{ctx.protected_args[0]}'.")
+            click.echo(ctx.get_help(), color=ctx.color)
+            ctx.exit()
+
         # All non-help cases reach here
         return super().invoke(ctx)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -200,3 +200,14 @@ def test_e2e_manifest(cli_runner, data_dir: Path, tmp_path: Path, test_image_tif
     manifest_file_bytes = manifest_path.read_bytes()
     assert b"study_slide_1.tif" in manifest_file_bytes
     assert str(test_image_tiff).encode() in manifest_file_bytes
+
+
+@pytest.mark.parametrize("args", [["foo"], ["-r", "foo"]])
+def test_e2e_no_such_command(cli_runner, args):
+    result = cli_runner.invoke(main.imagedephi, args)
+    assert result.exit_code == 0
+
+    # Assert that the user has been told their command was invalid
+    assert "No such command" in result.output
+    # Assert the usage docs are shown to the user
+    assert "Usage: imagedephi" in result.output


### PR DESCRIPTION
Fix #70 

Modify the `invoke` method of `FallthroughGroup` by handling the case where a provided subcommand does not match a subcommand actually offered by the `FallthroughGroup`.