### PR TITLE
Guard the list items height check

### DIFF
--- a/client/src/components/FileBrowser.vue
+++ b/client/src/components/FileBrowser.vue
@@ -89,7 +89,7 @@ const calculateVisibleItems = () => {
     const listHeight = ref(0);
     const visibleItems = ref(0);
     // Determine the height of each list item
-    const listItemHeight = listItems ? listItems[0].clientHeight : 0;
+    const listItemHeight = listItems && listItems[0] ? listItems[0].clientHeight : 0;
 
     directoryData.value.childrenImages.forEach(() => {
       listHeight.value += listItemHeight;


### PR DESCRIPTION
@marySalvi I found that if I navigated through directories with zero readable images, a javascript error would be thrown and then the image list would never be shown in the open dialog.  This fixes it on my system.