### PR TITLE
Unpin dependencies and fix test rule definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "ImageDePHI"
 requires-python = ">=3.11"
 dependencies = [
-    "click<8.1.4",
+    "click",
     "tifftools",
     "fastapi",
     "python-multipart",
@@ -14,8 +14,7 @@ dependencies = [
     "pyyaml",
     "Pillow",
     "pooch",
-    # Pinned to < 3 until wsidicom is updated
-    "pydicom<3",
+    "pydicom",
     "tqdm",
     "wsidicom",
     "websockets",

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -196,11 +196,11 @@ def test_strict_skip_dcm(dcm_input_path, tmp_path) -> None:
 def test_dcm_private_redaction(dcm_input_path, tmp_path, action, custom_tag_exists) -> None:
     override_ruleset = Ruleset()
     override_ruleset.dicom.custom_metadata_action = action
-
     if action == "use_rule":
-        override_ruleset.dicom.metadata["(1001, 1001)"] = KeepRule(
+        override_ruleset.dicom.metadata["(1001,1001)"] = KeepRule(
             key_name="TestItem", action="keep"
         )
+
     override_rules = tmp_path / "override_rules.yaml"
     with override_rules.open("w") as override_rules_stream:
         yaml.safe_dump(override_ruleset.model_dump(), override_rules_stream)


### PR DESCRIPTION
Looks like there's a difference in representation of tags in (gggg, eeee) form between pydicom 2.X and 3.0. This caused a test to fail for us. 

If using (gggg,eeee) form in rules, they must not have a space after the comma.