### PR TITLE
Better ignore node_modules in linting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     yamlfix
 commands =
     flake8 {posargs:.}
-    yamlfix -c pyproject.toml --exclude ./client/node_modules/**/* client docs .github imagedephi stubs tests --check
+    yamlfix -c pyproject.toml --exclude **/node_modules/**/* client docs .github imagedephi stubs tests --check
 
 [testenv:format]
 package = skip
@@ -34,7 +34,7 @@ deps =
 commands =
     isort {posargs:.}
     black {posargs:.}
-    yamlfix -c pyproject.toml --exclude ./client/node_modules/**/* client docs .github imagedephi stubs tests
+    yamlfix -c pyproject.toml --exclude **/node_modules/**/* client docs .github imagedephi stubs tests
 
 [testenv:type]
 # Editable ensures dependencies are installed, but full packaging isn't necessary


### PR DESCRIPTION
When we run tox multiple times in a row, this was trying to lint node_modules.  Stop that.